### PR TITLE
MAT-1037: Publishing 0.0.1 to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-info-parser",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "This is a library to parse a modelinfo.xml specification file and generate libraries conforming to that specification.",
   "main": "dist/generateTypeScript.js",
   "repository": "git@github.com:MeasureAuthoringTool/model-info-parser.git",


### PR DESCRIPTION
Running `npm init` cleaned up our package.json file a bit. The only other thing to notice is bumping the version from 0.0.0 to 0.0.1.

When we merge this to master, with the right commit message, it should trigger a tag and an automatic publish to NPM