### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
         with: # All of theses inputs are optional
           tag_name: "v%s"
           tag_message: "v%s"
-          commit_pattern: "^Release (\\S+)"
+          commit_pattern: "[\\s\\S]*Release (\\S+)"
         env: # More info about the environment variables in the README
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -71,7 +71,7 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage/lcov.info
+          coverage-reports: lcov.info
 
   upload-codecov-coverage:
     name: Upload code coveage to Codecov
@@ -86,7 +86,7 @@ jobs:
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: coverage/lcov.info
+          file: lcov.info
           fail_ci_if_error: true # optional (default = false)
 #          flags: unittests # optional
 #          name: codecov-umbrella # optional

--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -4,6 +4,7 @@
 # - build the source code
 # - run tests and capture code coverage
 # - upload the code coverage report to Codacy
+# - upload the code coverage report to Codecov
 
 name: Continuous Integration
 
@@ -15,19 +16,16 @@ on:
 
 jobs:
   build:
+    name: Checkout, install, lint, build and test with coverage
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14.x'
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -35,9 +33,8 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
@@ -54,17 +51,37 @@ jobs:
       - name: Execute test coverage
         run: npm run-script coverage
 
-      - name: Store the HTML coverage report as an artifact
+      - name: Store the coverage report as an artifact
         uses: actions/upload-artifact@v2
         with:
-          name: coverage-report
-          path: coverage/lcov-report
+          name: coverage
+          path: coverage/lcov.info
+
+  upload-codacy-coverage:
+    name: Upload code coverage to Codacy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
 
       - name: Upload code coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
+
+  upload-codecov-coverage:
+    name: Upload code coveage to Codecov
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
 
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -73,4 +90,3 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
 #          flags: unittests # optional
 #          name: codecov-umbrella # optional
-


### PR DESCRIPTION
Tweaked the regex in the npm-publix workflow so that it'd actually work with a GitHub PR
Updated the CI workflow: removed the matrix, and broke apart the workflow into 3 separate jobs. The first one builds/tests/lints/etc, and the second and third upload coverage in parallel