### PR TITLE
MAT-1089 Address primitive extensions for FHIR mongoids

### DIFF
--- a/src/templates/rubymongoid/classTemplate.ts
+++ b/src/templates/rubymongoid/classTemplate.ts
@@ -7,7 +7,8 @@ export const source = `module {{namespace}}
     include Mongoid::Document
     field :typeName, type: String, default: '{{name}}'
     {{#each memberVariables}}
-    {{#if this.dataType.primitive}}{{> mongoidPrimitiveMember member=this}}{{else}}{{> mongoidComplexMember member=this}}{{/if}}
+    {{> mongoidComplexMember member=this}}
+    
     {{/each}}
   end
 end

--- a/src/templates/rubymongoid/complexMemberTemplate.ts
+++ b/src/templates/rubymongoid/complexMemberTemplate.ts
@@ -1,3 +1,4 @@
 export const source =
-  "{{#if member.isArray}}embeds_many{{else}}embeds_one{{/if}} :{{member.variableName}}, " +
-  "class_name: '{{member.dataType.normalizedName}}'";
+  "{{#if member.dataType.systemType}}{{> mongoidSystemMember member=member}}" +
+  "{{else}}{{#if member.isArray}}embeds_many{{else}}embeds_one{{/if}} :{{member.variableName}}, " +
+  "class_name: '{{member.dataType.normalizedName}}' {{/if}}";

--- a/src/templates/rubymongoid/primitiveMemberTemplate.ts
+++ b/src/templates/rubymongoid/primitiveMemberTemplate.ts
@@ -1,2 +1,0 @@
-export const source = `field :{{member.variableName}}, type: {{#if member.isArray}}Array{{else}}{{#getMongoidPrimitive member.dataType.normalizedName}}{{/getMongoidPrimitive}}{{/if}} # primitive
-    {{#if member.isArray}}embeds_many{{else}}embeds_one{{/if}} :_{{member.variableName}}, class_name: 'Extension'`;

--- a/src/templates/rubymongoid/registerPartials.ts
+++ b/src/templates/rubymongoid/registerPartials.ts
@@ -1,10 +1,10 @@
 import Handlebars from 'handlebars';
 import { getMongoidPrimitive, removeNamespace } from '../helpers/templateHelpers';
 import { source as mongoidComplexMember } from './complexMemberTemplate';
-import { source as mongoidPrimitiveMember } from './primitiveMemberTemplate';
+import { source as mongoidSystemMember } from './systemMemberTemplate';
 
 Handlebars.registerPartial('mongoidComplexMember', mongoidComplexMember);
-Handlebars.registerPartial('mongoidPrimitiveMember', mongoidPrimitiveMember);
+Handlebars.registerPartial('mongoidSystemMember', mongoidSystemMember);
 
 Handlebars.registerHelper('removeNamespace', removeNamespace);
 Handlebars.registerHelper('getMongoidPrimitive', getMongoidPrimitive);

--- a/src/templates/rubymongoid/systemMemberTemplate.ts
+++ b/src/templates/rubymongoid/systemMemberTemplate.ts
@@ -1,0 +1,1 @@
+export const source = `field :{{member.variableName}}, type: {{#if member.isArray}}Array{{else}}{{#getMongoidPrimitive member.dataType.normalizedName}}{{/getMongoidPrimitive}}{{/if}}`;


### PR DESCRIPTION
Added custom primitives( to address primitive extensions) to FHIR mongoids to make it similar to typescript models
e.g.

```
module FHIR
  class PrimitiveString < Element
    include Mongoid::Document
    field :typeName, type: String, default: 'PrimitiveString'
    field :value, type: String    
  end
end
```

```
module FHIR
  class Account < DomainResource
    include Mongoid::Document   
    embeds_one :name, class_name: 'PrimitiveString'     
    embeds_many :subject, class_name: 'Reference'   
  end
end
```