### PR TITLE
MAT-1146 and MAT-1147: Measure relationships

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,22 +30,26 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": ["error"],
     "@typescript-eslint/naming-convention": [
       "error",
+      { selector: "typeLike", format: ["PascalCase"] },
+      { selector: "enumMember", format: ["PascalCase"] },
+      { selector: "variableLike", format: ["camelCase"] },
       {
-        "selector": "interface",
-        "format": ["PascalCase"],
-        "custom": {
-          "regex": "^I[A-Z]",
-          "match": false
-        }
-      }, {
-        "selector": "typeAlias",
-        "format": ["PascalCase"],
-        "custom": {
-          "regex": "^I[A-Z]",
-          "match": false
-        }
-      }
+        selector: "interface",
+        format: ["PascalCase"],
+        custom: {
+          regex: "^I[A-Z]",
+          match: false,
+        },
+      },
+      {
+        selector: "typeAlias",
+        format: ["PascalCase"],
+        custom: {
+          regex: "^I[A-Z]",
+          match: false,
+        },
+      },
     ],
-    "class-methods-use-this": "off"
+    "class-methods-use-this": "off",
   },
 };

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Code owners:
-* @AndrewBird81 @adongare @jkotanchik-SB @RohitKandimalla @serhii-ilin
+* @AndrewBird81 @adongare @jkotanchik-SB @serhii-ilin

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "Andrew Bird <andrew.bird@semanticbits.com>",
     "Ashok Dongare <ashok.dongare@semanticbits.com>",
     "Joseph Kotanchik <joseph.kotanchik@semanticbits.com>",
-    "Rohit Kandimalla <rohit.kandimalla@semanticbits.com>",
     "Serhii Ilin <serhii.ilin@semanticbits.com>"
   ],
   "bugs": {

--- a/src/model/dataTypes/MemberVariable.ts
+++ b/src/model/dataTypes/MemberVariable.ts
@@ -5,6 +5,15 @@ import ListElement from "../modelInfo/ListElement";
 import SimpleElement from "../modelInfo/SimpleElement";
 import FilePath from "./FilePath";
 
+export const enum RelationshipType {
+  embeds_one = "embeds_one",
+  embeds_many = "embeds_many",
+  belongs_to = "belongs_to",
+  has_one = "has_one",
+  has_many = "has_many",
+  has_and_belongs_to_many = "has_and_belongs_to_many",
+}
+
 export default class MemberVariable {
   public readonly dataType: DataType;
 
@@ -12,14 +21,40 @@ export default class MemberVariable {
 
   public readonly isArray: boolean;
 
-  constructor(dataType: DataType, variableName: string, isArray = false) {
+  public readonly relationshipType: RelationshipType;
+
+  public readonly bidirectional: boolean;
+
+  constructor(
+    dataType: DataType,
+    variableName: string,
+    isArray = false,
+    relationshipType?: RelationshipType,
+    bidirectional = true
+  ) {
     this.dataType = dataType;
     this.variableName = variableName;
     this.isArray = isArray;
+    this.bidirectional = bidirectional;
+
+    // If not specified, default to "embeds_many" for arrays, and "embeds_one" for non-arrays
+    if (!relationshipType) {
+      this.relationshipType = isArray
+        ? RelationshipType.embeds_many
+        : RelationshipType.embeds_one;
+    } else {
+      this.relationshipType = relationshipType;
+    }
   }
 
   public clone(): MemberVariable {
-    return new MemberVariable(this.dataType, this.variableName, this.isArray);
+    return new MemberVariable(
+      this.dataType,
+      this.variableName,
+      this.isArray,
+      this.relationshipType,
+      this.bidirectional
+    );
   }
 
   /**

--- a/src/model/dataTypes/MemberVariable.ts
+++ b/src/model/dataTypes/MemberVariable.ts
@@ -6,12 +6,12 @@ import SimpleElement from "../modelInfo/SimpleElement";
 import FilePath from "./FilePath";
 
 export const enum RelationshipType {
-  embeds_one = "embeds_one",
-  embeds_many = "embeds_many",
-  belongs_to = "belongs_to",
-  has_one = "has_one",
-  has_many = "has_many",
-  has_and_belongs_to_many = "has_and_belongs_to_many",
+  EmbedsOne = "embeds_one",
+  EmbedsMany = "embeds_many",
+  BelongsTo = "belongs_to",
+  HasOne = "has_one",
+  HasMany = "has_many",
+  HasAndBelongsToMany = "has_and_belongs_to_many",
 }
 
 export default class MemberVariable {
@@ -40,8 +40,8 @@ export default class MemberVariable {
     // If not specified, default to "embeds_many" for arrays, and "embeds_one" for non-arrays
     if (!relationshipType) {
       this.relationshipType = isArray
-        ? RelationshipType.embeds_many
-        : RelationshipType.embeds_one;
+        ? RelationshipType.EmbedsMany
+        : RelationshipType.EmbedsOne;
     } else {
       this.relationshipType = relationshipType;
     }

--- a/src/model/dataTypes/system/SystemBoolean.ts
+++ b/src/model/dataTypes/system/SystemBoolean.ts
@@ -1,5 +1,3 @@
 import DataType from "../DataType";
 
-const SystemBoolean = DataType.getInstance("System", "boolean", `${__dirname}/system`);
-
-export default SystemBoolean;
+export default DataType.getInstance("System", "boolean", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemDate.ts
+++ b/src/model/dataTypes/system/SystemDate.ts
@@ -1,5 +1,3 @@
 import DataType from "../DataType";
 
-const SystemDate = DataType.getInstance("System", "Date", `${__dirname}/system`);
-
-export default SystemDate;
+export default DataType.getInstance("System", "Date", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemDateTime.ts
+++ b/src/model/dataTypes/system/SystemDateTime.ts
@@ -1,5 +1,3 @@
 import DataType from "../DataType";
 
-const SystemDateTime = DataType.getInstance("System", "Date", `${__dirname}/system`);
-
-export default SystemDateTime;
+export default DataType.getInstance("System", "Date", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemDecimal.ts
+++ b/src/model/dataTypes/system/SystemDecimal.ts
@@ -2,6 +2,4 @@ import DataType from "../DataType";
 
 // TODO this should use a better "big nubmer" system like https://github.com/jtobey/javascript-bignum
 // See https://www.hl7.org/fhir/json.html
-const SystemDecimal = DataType.getInstance("System", "number", `${__dirname}/system`);
-
-export default SystemDecimal;
+export default DataType.getInstance("System", "number", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemInteger.ts
+++ b/src/model/dataTypes/system/SystemInteger.ts
@@ -2,6 +2,4 @@ import DataType from "../DataType";
 
 // TODO this should use a better "big nubmer" system like https://github.com/jtobey/javascript-bignum
 // See https://www.hl7.org/fhir/json.html
-const SystemInteger = DataType.getInstance("System", "number", `${__dirname}/system`);
-
-export default SystemInteger;
+export default DataType.getInstance("System", "number", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemString.ts
+++ b/src/model/dataTypes/system/SystemString.ts
@@ -1,5 +1,3 @@
 import DataType from "../DataType";
 
-const SystemString = DataType.getInstance("System", "string", `${__dirname}/system`);
-
-export default SystemString;
+export default DataType.getInstance("System", "string", `${__dirname}/system`);

--- a/src/model/dataTypes/system/SystemTime.ts
+++ b/src/model/dataTypes/system/SystemTime.ts
@@ -1,5 +1,3 @@
 import DataType from "../DataType";
 
-const SystemTime = DataType.getInstance("System", "Date", `${__dirname}/system`);
-
-export default SystemTime;
+export default DataType.getInstance("System", "Date", `${__dirname}/system`);

--- a/src/preprocessors/MongoidPreprocessor.ts
+++ b/src/preprocessors/MongoidPreprocessor.ts
@@ -49,7 +49,7 @@ export default class MongoidPreprocessor extends BasePreprocessor {
       valueSetType,
       "valueSets",
       true,
-      RelationshipType.has_and_belongs_to_many,
+      RelationshipType.HasAndBelongsToMany,
       false
     );
 
@@ -58,7 +58,7 @@ export default class MongoidPreprocessor extends BasePreprocessor {
       patientType,
       "patients",
       true,
-      RelationshipType.has_and_belongs_to_many,
+      RelationshipType.HasAndBelongsToMany,
       false
     );
 

--- a/src/preprocessors/MongoidPreprocessor.ts
+++ b/src/preprocessors/MongoidPreprocessor.ts
@@ -1,11 +1,90 @@
 import BasePreprocessor from "./BasePreprocessor";
 import EntityCollection from "../model/dataTypes/EntityCollection";
+import TransformedPredicate from "../collectionUtils/core/TransformedPredicate";
+import ExtractDataTypeTransformer from "../collectionUtils/ExtractDataTypeTransformer";
+import IsDataTypePredicate from "../collectionUtils/IsDataTypePredicate";
+import MemberVariable, {
+  RelationshipType,
+} from "../model/dataTypes/MemberVariable";
+import DataType from "../model/dataTypes/DataType";
+import AddMemberVariableTransformer from "../collectionUtils/AddMemberVariableTransformer";
+import IfTransformer from "../collectionUtils/core/IfTransformer";
+import NOPTransformer from "../collectionUtils/core/NOPTransformer";
+import EntityDefinition from "../model/dataTypes/EntityDefinition";
+import ChainedTransformer from "../collectionUtils/core/ChainedTransformer";
 
 /**
  * EntityCollection Preprocessor for the Mongoid-specific model generation
  */
 export default class MongoidPreprocessor extends BasePreprocessor {
   preprocess(entityCollection: EntityCollection): EntityCollection {
-    return super.preprocess(entityCollection);
+    // Perform all the "base" transformations
+    const startingCollection = super.preprocess(entityCollection);
+
+    // Predicate that checks if a DataType is for FHIR.Measure
+    const measureDataTypePredicate = new IsDataTypePredicate("FHIR", "Measure");
+
+    // Predicate that checks if an EntityDefinition is for FHIR.Measure
+    const measureEntityPredicate = new TransformedPredicate(
+      ExtractDataTypeTransformer.INSTANCE,
+      measureDataTypePredicate
+    );
+
+    // ValueSet DataType
+    const valueSetType = DataType.getInstance(
+      "FHIR",
+      "ValueSet",
+      entityCollection.baseDir
+    );
+
+    // Patient DataType
+    const patientType = DataType.getInstance(
+      "FHIR",
+      "Patient",
+      entityCollection.baseDir
+    );
+
+    // ValueSet MemberVariable to add
+    const valueSetCollectionMember = new MemberVariable(
+      valueSetType,
+      "valueSets",
+      true,
+      RelationshipType.has_and_belongs_to_many,
+      false
+    );
+
+    // Patient MemberVariable to add
+    const patientCollectionMember = new MemberVariable(
+      patientType,
+      "patients",
+      true,
+      RelationshipType.has_and_belongs_to_many,
+      false
+    );
+
+    // Transformer to add the "valueSets" member variable
+    const addValueSetsTransformer = new AddMemberVariableTransformer(
+      valueSetCollectionMember
+    );
+
+    // Transformer to add the "patients" member variable
+    const addPatientsTransformer = new AddMemberVariableTransformer(
+      patientCollectionMember
+    );
+
+    // Chained transformer that performs all modifications
+    const chainedTransformer = new ChainedTransformer(
+      addValueSetsTransformer,
+      addPatientsTransformer
+    );
+
+    // Transformer that only modifies the Measure entity
+    const ifTransformer = new IfTransformer(
+      measureEntityPredicate,
+      chainedTransformer,
+      new NOPTransformer<EntityDefinition>()
+    );
+
+    return startingCollection.transform(ifTransformer);
   }
 }

--- a/src/templates/rubymongoid/complexMemberTemplate.ts
+++ b/src/templates/rubymongoid/complexMemberTemplate.ts
@@ -1,3 +1,4 @@
 export default "{{# if member.dataType.systemType }}{{> mongoidSystemMember member=member }}" +
-  "{{ else }}{{# if member.isArray }}embeds_many{{ else }}embeds_one{{/ if }} :{{ member.variableName }}, " +
-  "class_name: '{{ member.dataType.normalizedName }}' {{/ if }}";
+  "{{ else }}{{ member.relationshipType }} :{{ member.variableName }}, " +
+  "class_name: '{{ member.dataType.normalizedName }}'{{/ if }}" +
+  "{{# unless member.bidirectional }}, inverse_of: nil{{/ unless }}";

--- a/test/model/dataTypes/MemberVariable.test.ts
+++ b/test/model/dataTypes/MemberVariable.test.ts
@@ -94,12 +94,12 @@ describe("MemberVariable", () => {
 
     it("defaults the relationshipType to embeds_one if isArray is false", () => {
       const result = new MemberVariable(systemBool, "testVar", false);
-      expect(result.relationshipType).toBe(RelationshipType.embeds_one);
+      expect(result.relationshipType).toBe(RelationshipType.EmbedsOne);
     });
 
     it("defaults the relationshipType to embeds_many if isArray is true", () => {
       const result = new MemberVariable(systemBool, "testVar", true);
-      expect(result.relationshipType).toBe(RelationshipType.embeds_many);
+      expect(result.relationshipType).toBe(RelationshipType.EmbedsMany);
     });
 
     it("allows the specification of a custom relationshipType", () => {
@@ -107,9 +107,9 @@ describe("MemberVariable", () => {
         systemBool,
         "testVar",
         true,
-        RelationshipType.belongs_to
+        RelationshipType.BelongsTo
       );
-      expect(result.relationshipType).toBe(RelationshipType.belongs_to);
+      expect(result.relationshipType).toBe(RelationshipType.BelongsTo);
     });
 
     it("defaults the bidirectional property to true", () => {
@@ -122,7 +122,7 @@ describe("MemberVariable", () => {
         systemBool,
         "testVar",
         true,
-        RelationshipType.has_and_belongs_to_many,
+        RelationshipType.HasOne,
         false
       );
       expect(result.bidirectional).toBeFalse();
@@ -217,7 +217,7 @@ describe("MemberVariable", () => {
         systemBool,
         "testVar",
         true,
-        RelationshipType.has_many,
+        RelationshipType.HasMany,
         false
       );
       const result = original.clone();
@@ -225,7 +225,7 @@ describe("MemberVariable", () => {
       expect(result.dataType).toEqual(systemBool);
       expect(result.variableName).toEqual("testVar");
       expect(result.isArray).toBeTrue();
-      expect(result.relationshipType).toBe(RelationshipType.has_many);
+      expect(result.relationshipType).toBe(RelationshipType.HasMany);
       expect(result.bidirectional).toBeFalse();
     });
   });

--- a/test/model/dataTypes/MemberVariable.test.ts
+++ b/test/model/dataTypes/MemberVariable.test.ts
@@ -5,7 +5,9 @@ import ChoiceElement, {
 } from "../../../src/model/modelInfo/ChoiceElement";
 import ListElement from "../../../src/model/modelInfo/ListElement";
 import SimpleElement from "../../../src/model/modelInfo/SimpleElement";
-import MemberVariable from "../../../src/model/dataTypes/MemberVariable";
+import MemberVariable, {
+  RelationshipType,
+} from "../../../src/model/dataTypes/MemberVariable";
 import FilePath from "../../../src/model/dataTypes/FilePath";
 import DataType from "../../../src/model/dataTypes/DataType";
 
@@ -88,6 +90,42 @@ describe("MemberVariable", () => {
     it("allows explicit isArray initialization", () => {
       const result = new MemberVariable(systemBool, "testVar", true);
       expect(result.isArray).toBeTrue();
+    });
+
+    it("defaults the relationshipType to embeds_one if isArray is false", () => {
+      const result = new MemberVariable(systemBool, "testVar", false);
+      expect(result.relationshipType).toBe(RelationshipType.embeds_one);
+    });
+
+    it("defaults the relationshipType to embeds_many if isArray is true", () => {
+      const result = new MemberVariable(systemBool, "testVar", true);
+      expect(result.relationshipType).toBe(RelationshipType.embeds_many);
+    });
+
+    it("allows the specification of a custom relationshipType", () => {
+      const result = new MemberVariable(
+        systemBool,
+        "testVar",
+        true,
+        RelationshipType.belongs_to
+      );
+      expect(result.relationshipType).toBe(RelationshipType.belongs_to);
+    });
+
+    it("defaults the bidirectional property to true", () => {
+      const result = new MemberVariable(systemBool, "testVar");
+      expect(result.bidirectional).toBeTrue();
+    });
+
+    it("allows setting the bidirectional property to false", () => {
+      const result = new MemberVariable(
+        systemBool,
+        "testVar",
+        true,
+        RelationshipType.has_and_belongs_to_many,
+        false
+      );
+      expect(result.bidirectional).toBeFalse();
     });
   });
 
@@ -175,12 +213,20 @@ describe("MemberVariable", () => {
 
   describe("clone", () => {
     it("should make a deep copy of the MemberVariable", () => {
-      const original = new MemberVariable(systemBool, "testVar", true);
+      const original = new MemberVariable(
+        systemBool,
+        "testVar",
+        true,
+        RelationshipType.has_many,
+        false
+      );
       const result = original.clone();
       expect(original).not.toBe(result);
       expect(result.dataType).toEqual(systemBool);
       expect(result.variableName).toEqual("testVar");
       expect(result.isArray).toBeTrue();
+      expect(result.relationshipType).toBe(RelationshipType.has_many);
+      expect(result.bidirectional).toBeFalse();
     });
   });
 });

--- a/test/preprocessors/MongoidPreprocessor.test.ts
+++ b/test/preprocessors/MongoidPreprocessor.test.ts
@@ -51,10 +51,10 @@ describe("MongoidPreprocessor", () => {
     // Second entity has 2 new members
     expect(entities[1].memberVariables).toBeArrayOfSize(4);
     expect(entities[1].memberVariables[2].relationshipType).toBe(
-      RelationshipType.has_and_belongs_to_many
+      RelationshipType.HasAndBelongsToMany
     );
     expect(entities[1].memberVariables[3].relationshipType).toBe(
-      RelationshipType.has_and_belongs_to_many
+      RelationshipType.HasAndBelongsToMany
     );
     expect(entities[1].memberVariables[2].variableName).toBe("valueSets");
     expect(entities[1].memberVariables[3].variableName).toBe("patients");

--- a/test/preprocessors/MongoidPreprocessor.test.ts
+++ b/test/preprocessors/MongoidPreprocessor.test.ts
@@ -3,24 +3,62 @@ import EntityDefinitionBuilder from "../model/dataTypes/EntityDefinitionBuilder"
 import EntityDefinition from "../../src/model/dataTypes/EntityDefinition";
 import EntityCollection from "../../src/model/dataTypes/EntityCollection";
 import FilePath from "../../src/model/dataTypes/FilePath";
+import DataType from "../../src/model/dataTypes/DataType";
+import { RelationshipType } from "../../src/model/dataTypes/MemberVariable";
 
 describe("MongoidPreprocessor", () => {
-  const entityBuilder = new EntityDefinitionBuilder();
-
+  let entityBuilder;
   let preprocessor: MongoidPreprocessor;
   let entityDefinition: EntityDefinition;
+  let measureDefinition: EntityDefinition;
   let entityCollection: EntityCollection;
 
   beforeEach(() => {
+    entityBuilder = new EntityDefinitionBuilder();
     preprocessor = new MongoidPreprocessor();
+
     entityDefinition = entityBuilder.buildEntityDefinition();
+
+    entityBuilder = new EntityDefinitionBuilder();
+    entityBuilder.dataType = DataType.getInstance(
+      "FHIR",
+      "Measure",
+      entityBuilder.dataType.path
+    );
+    measureDefinition = entityBuilder.buildEntityDefinition();
+
     entityCollection = new EntityCollection(
-      [entityDefinition],
+      [entityDefinition, measureDefinition],
       FilePath.getInstance("/tmp")
     );
   });
 
-  it("should do nothing extra for now", () => {
-    expect(preprocessor.preprocess(entityCollection)).not.toBe(entityCollection);
+  it("should add two additional member variables to the Measure type (only)", () => {
+    // preconditions
+    expect(entityCollection.entities).toBeArrayOfSize(2);
+    expect(entityCollection.entities[0].memberVariables).toBeArrayOfSize(2);
+    expect(entityCollection.entities[1].memberVariables).toBeArrayOfSize(2);
+
+    const result = preprocessor.preprocess(entityCollection);
+
+    expect(result).not.toBe(entityCollection);
+    const { entities } = result;
+    expect(entities).toBeArrayOfSize(2);
+
+    // First entity unchanged
+    expect(entities[0].memberVariables).toBeArrayOfSize(2);
+
+    // Second entity has 2 new members
+    expect(entities[1].memberVariables).toBeArrayOfSize(4);
+    expect(entities[1].memberVariables[2].relationshipType).toBe(
+      RelationshipType.has_and_belongs_to_many
+    );
+    expect(entities[1].memberVariables[3].relationshipType).toBe(
+      RelationshipType.has_and_belongs_to_many
+    );
+    expect(entities[1].memberVariables[2].variableName).toBe("valueSets");
+    expect(entities[1].memberVariables[3].variableName).toBe("patients");
+    expect(entities[1].memberVariables[2].bidirectional).toBeFalse();
+    expect(entities[1].memberVariables[3].bidirectional).toBeFalse();
   });
 });


### PR DESCRIPTION
Added the "valueSets" and "patients" references on the generated FHIR Mongoid Measure model. 

In order to accomplish this, I added a new set of fields on MemberVariable that are specific to Mongoid models. We needed a way to represent both embedded and external MongoDB documents
