### PR TITLE
MAT-1171: Fixed handling of primitive type JSON

### DIFF
--- a/src/templates/rubymongoid/classTemplate.ts
+++ b/src/templates/rubymongoid/classTemplate.ts
@@ -38,7 +38,14 @@ export const source = `module {{ dataType.namespace }}
     {{/ isPrimitiveType ~}}
 
     {{!--
-      Loop over each member variable and add the conversion logic from the Measure JSON to 
+      If this is a primitive type, the json_hash isn't really a hash, it's the value
+    --}}
+    {{# isPrimitiveType this.dataType }}
+      result['value'] = json_hash
+    {{~ else ~}}
+
+    {{!--
+      For non-primitive types, loop over each member variable and add the conversion logic from the Measure JSON to 
       the Mongo JSON we're using internally
     --}}
     {{# each memberVariables }}
@@ -79,6 +86,7 @@ export const source = `module {{ dataType.namespace }}
     {{/ if }}
     {{/ isSystemType }}
     {{~/ each }}
+    {{~/ isPrimitiveType }}
 
       result
     end

--- a/src/templates/rubymongoid/classTemplate.ts
+++ b/src/templates/rubymongoid/classTemplate.ts
@@ -71,9 +71,6 @@ export const source = `module {{ dataType.namespace }}
       result['{{ prefixVariableName this.variableName }}'] = json_hash['{{this.variableName}}'].each_with_index.map do |var, i|
         {{ this.dataType.normalizedName }}.transform_json(var, json_hash['_{{this.variableName}}'][i])
       end 
-    
-      {{> transformMember variableName=this.variableName className=this.dataType.normalizedName }}
-      
     {{ else }}
       result['{{ prefixVariableName this.variableName }}'] = json_hash['{{this.variableName}}'].map { |var| {{this.dataType.normalizedName}}.transform_json(var) }
     {{/ isPrimitiveType }}

--- a/test/templates/helpers/templateHelpers.test.ts
+++ b/test/templates/helpers/templateHelpers.test.ts
@@ -132,7 +132,11 @@ describe("templateHelpers", () => {
   describe("getRobyDoc", () => {
     it("should return namespace/datatype.rb string", () => {
       const accountType = DataType.getInstance("FHIR", "Account", "/tmp");
-      const accountCoverageType = DataType.getInstance("FHIR", "AccountCoverage", "/tmp");
+      const accountCoverageType = DataType.getInstance(
+        "FHIR",
+        "AccountCoverage",
+        "/tmp"
+      );
 
       const source = "{{# getRobyDoc this}}{{/ getRobyDoc}}";
       const template = Handlebars.compile(source);


### PR DESCRIPTION
For primitive types, we were incorrectly retrieving a value like this:

`result['value'] = json_hash['value']`

But for primitives, `json_hash` _is_ the value:

`result['value'] = json_hash`