### PR TITLE
MAT-1198: Initialize super class members in Mongoid transform_json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testEnvironment: "node",
   roots: ["<rootDir>/src/", "<rootDir>/test/"],
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
-  collectCoverageFrom: [
-    "src/**/*.ts",
-    "!**/node_modules/**"
-  ],
-  setupFilesAfterEnv: ['jest-extended']
+  collectCoverageFrom: ["src/**/*.ts", "!**/node_modules/**"],
+  setupFilesAfterEnv: ["jest-extended"],
 };

--- a/src/collectionUtils/CollectionUtils.ts
+++ b/src/collectionUtils/CollectionUtils.ts
@@ -13,7 +13,10 @@ export default class CollectionUtils {
     return input.filter((val: T) => !predicate.evaluate(val));
   }
 
-  public static transform<T, K>(input: Array<T>, transformer: Transformer<T, K>): Array<K> {
+  public static transform<T, K>(
+    input: Array<T>,
+    transformer: Transformer<T, K>
+  ): Array<K> {
     return input.map((value: T) => transformer.transform(value));
   }
 }

--- a/src/collectionUtils/core/ChainedTransformer.ts
+++ b/src/collectionUtils/core/ChainedTransformer.ts
@@ -18,8 +18,11 @@ export default class ChainedTransformer<T> extends Transformer<T, T> {
       throw new Error("Cannot chain 0 transformers together");
     }
 
-    return this.transformers.reduce((accumulator: T, currentTransformer: Transformer<T, T>) => {
-      return currentTransformer.transform(accumulator);
-    }, input);
+    return this.transformers.reduce(
+      (accumulator: T, currentTransformer: Transformer<T, T>) => {
+        return currentTransformer.transform(accumulator);
+      },
+      input
+    );
   }
 }

--- a/src/generators/MongooseTypeGenerator.ts
+++ b/src/generators/MongooseTypeGenerator.ts
@@ -1,19 +1,23 @@
 import _ from "lodash";
 import FileWriter from "../FileWriter";
-import {mongoosePrimitiveTypes} from "../model/dataTypes/primitiveDataTypes";
-import classTemplate, {TemplateContext} from "../templates/mongoose/classTemplate";
+import { mongoosePrimitiveTypes } from "../model/dataTypes/primitiveDataTypes";
+import classTemplate, {
+  TemplateContext,
+} from "../templates/mongoose/classTemplate";
 import Generator from "./Generator";
 import FilePath from "../model/dataTypes/FilePath";
 import EntityDefinition from "../model/dataTypes/EntityDefinition";
 import EntityCollection from "../model/dataTypes/EntityCollection";
-import exportModelsTemplate from "../templates/mongoose/allMongooseExportTemplate"
+import exportModelsTemplate from "../templates/mongoose/allMongooseExportTemplate";
 import DataType from "../model/dataTypes/DataType";
 
 async function generate(
   entityDefinition: EntityDefinition,
   baseDirectory: FilePath
 ): Promise<string> {
-  if (mongoosePrimitiveTypes[_.lowerFirst(entityDefinition.dataType.typeName)]) {
+  if (
+    mongoosePrimitiveTypes[_.lowerFirst(entityDefinition.dataType.typeName)]
+  ) {
     return "";
   }
 
@@ -25,7 +29,7 @@ async function generate(
   };
 
   const contents: string = classTemplate(templateInput);
-  const {namespace, normalizedName} = entityDefinition.dataType;
+  const { namespace, normalizedName } = entityDefinition.dataType;
   const fileName = `${normalizedName}.js`;
 
   const writer = new FileWriter(
@@ -38,23 +42,36 @@ async function generate(
   return contents;
 }
 
-async function generateAllDataElements(dataTypes: Array<DataType>, baseDirectory: FilePath): Promise<void> {
-  const contents: string = exportModelsTemplate({dataTypes});
-  const writer = new FileWriter(contents, baseDirectory.value, null, "AllDataElements.js");
+async function generateAllDataElements(
+  dataTypes: Array<DataType>,
+  baseDirectory: FilePath
+): Promise<void> {
+  const contents: string = exportModelsTemplate({ dataTypes });
+  const writer = new FileWriter(
+    contents,
+    baseDirectory.value,
+    null,
+    "AllDataElements.js"
+  );
   await writer.writeFile();
 }
 
 /**
  * Generate all models
  */
-async function generateModels(entityCollection: EntityCollection): Promise<Array<string>> {
+async function generateModels(
+  entityCollection: EntityCollection
+): Promise<Array<string>> {
   const promises = entityCollection.entities.map(
     async (entity: EntityDefinition) => {
       return generate(entity, entityCollection.baseDir);
     }
   );
 
-  await generateAllDataElements(entityCollection.entities.map(e => e.dataType), entityCollection.baseDir);
+  await generateAllDataElements(
+    entityCollection.entities.map((e) => e.dataType),
+    entityCollection.baseDir
+  );
   return Promise.all(promises);
 }
 

--- a/src/model/TypeHierarchy.ts
+++ b/src/model/TypeHierarchy.ts
@@ -22,7 +22,7 @@ export default class TypeHierarchy {
     return `${type.namespace}.${type.typeName}`;
   }
 
-  public addType(type: DataType, parent: DataType|null): void {
+  public addType(type: DataType, parent: DataType | null): void {
     const key = TypeHierarchy.buildKey(type);
 
     // Add new type if it doesn't already exist

--- a/src/model/dataTypes/FilePath.ts
+++ b/src/model/dataTypes/FilePath.ts
@@ -29,7 +29,9 @@ export default class FilePath {
       // if the cached value and the incoming value are different, that means the cached file and this
       // new file have the same name, but different capitalization
       if (cachedFile.value !== normalizedValue) {
-        throw new Error(`FilePath "${normalizedValue}" cannot overwrite equivalent file "${cachedFile.value}"`);
+        throw new Error(
+          `FilePath "${normalizedValue}" cannot overwrite equivalent file "${cachedFile.value}"`
+        );
       }
 
       return cachedFile;

--- a/src/model/modelInfo/ListElement.ts
+++ b/src/model/modelInfo/ListElement.ts
@@ -10,7 +10,11 @@ import Element from "./Element";
  * </ns4:element>
  */
 export default class ListElement extends Element {
-  constructor(public name: string, public namespace: string, public typeName: string) {
+  constructor(
+    public name: string,
+    public namespace: string,
+    public typeName: string
+  ) {
     super(name);
   }
 }

--- a/src/model/modelInfo/ModelInfo.ts
+++ b/src/model/modelInfo/ModelInfo.ts
@@ -25,7 +25,8 @@ export default class ModelInfo {
   static createModelInfo(input: ModelInfoXml): ModelInfo {
     const modelInfoBase = input["ns4:modelInfo"];
     const { $: attrs } = modelInfoBase;
-    const typeInfoArray: Array<TypeInfoXml> = modelInfoBase["ns4:typeInfo"] || [];
+    const typeInfoArray: Array<TypeInfoXml> =
+      modelInfoBase["ns4:typeInfo"] || [];
     const { name, version } = attrs;
 
     const types: Array<TypeInfo> = typeInfoArray.reduce(

--- a/src/model/modelInfo/SimpleElement.ts
+++ b/src/model/modelInfo/SimpleElement.ts
@@ -7,7 +7,11 @@ import Element from "./Element";
  * <ns4:element name="title" elementType="FHIR.string"/>
  */
 export default class SimpleElement extends Element {
-  constructor(public name: string, public namespace: string, public typeName: string) {
+  constructor(
+    public name: string,
+    public namespace: string,
+    public typeName: string
+  ) {
     super(name);
   }
 }

--- a/src/templates/mongoose/registerPartials.ts
+++ b/src/templates/mongoose/registerPartials.ts
@@ -1,5 +1,10 @@
 import Handlebars from "handlebars";
-import {eq, getMongoosePrimitive, isSchemaFunctionIdRequired, isSchemaFunctionRequired,} from "./templateHelpers";
+import {
+  eq,
+  getMongoosePrimitive,
+  isSchemaFunctionIdRequired,
+  isSchemaFunctionRequired,
+} from "./templateHelpers";
 import mongooseMemberTemplate from "./mongooseMemberTemplate";
 
 Handlebars.registerPartial("mongooseMember", mongooseMemberTemplate);
@@ -11,6 +16,5 @@ Handlebars.registerHelper(
   isSchemaFunctionIdRequired
 );
 Handlebars.registerHelper("eq", eq);
-
 
 export default Handlebars;

--- a/src/templates/mongoose/templateHelpers.ts
+++ b/src/templates/mongoose/templateHelpers.ts
@@ -1,22 +1,27 @@
 import _ from "lodash";
-import {mongoosePrimitiveTypes} from "../../model/dataTypes/primitiveDataTypes";
+import { mongoosePrimitiveTypes } from "../../model/dataTypes/primitiveDataTypes";
 
 export function getMongoosePrimitive(typeName: string): string {
   return mongoosePrimitiveTypes[_.lowerFirst(typeName)];
 }
 
-const schemaFunctionRequired = new Set(['DomainResource', 'Resource', 'BackboneElement', 'Element', 'Quantity', 'ElementDefinition']);
+const schemaFunctionRequired = new Set([
+  "DomainResource",
+  "Resource",
+  "BackboneElement",
+  "Element",
+  "Quantity",
+  "ElementDefinition",
+]);
 
 export function isSchemaFunctionRequired(type: string): boolean {
   return schemaFunctionRequired.has(type);
 }
 
 export function isSchemaFunctionIdRequired(type: string): boolean {
-  return type === 'Resource' || type === 'Element';
+  return type === "Resource" || type === "Element";
 }
 
 export function eq(arg1: string, arg2: string): boolean {
   return arg1 === arg2;
 }
-
-

--- a/src/templates/rubymongoid/classTemplate.ts
+++ b/src/templates/rubymongoid/classTemplate.ts
@@ -24,17 +24,23 @@ export const source = `module {{ dataType.namespace }}
     end
     {{/ hasReservedKeywords }}
 
-    def self.transform_json(json_hash{{~# isPrimitiveType this.dataType ~}}, extension_hash{{~/ isPrimitiveType ~}})
-      result = {{ dataType.normalizedName }}.new
+    def self.transform_json(json_hash{{~# isPrimitiveType this.dataType ~}}, extension_hash{{~/ isPrimitiveType ~}}, target={{ dataType.normalizedName }}.new)
     {{!--
       If we're transforming a primitive type 'foo', we also need to get the 'id' and 'extension'
       values from the '_foo' attributes and set them accordingly                
     --}}
     {{# isPrimitiveType this.dataType }}
+      result = target
       unless extension_hash.nil?
         result['id'] = extension_hash['id']
         result['extension'] = extension_hash['extension'].map { |ext| Extension.transform_json(ext) }
       end
+    {{ else }}
+    {{# if parentDataType }}
+      result = super.transform_json(json_hash, target)
+    {{ else }}
+      result = target
+    {{/ if }}
     {{/ isPrimitiveType ~}}
 
     {{!--

--- a/test/collectionUtils/CollectionUtils.test.ts
+++ b/test/collectionUtils/CollectionUtils.test.ts
@@ -1,6 +1,8 @@
 import ContainsExtensionPredicate from "./testImpls/ContainsExtensionPredicate";
 import CollectionUtils from "../../src/collectionUtils/CollectionUtils";
-import ExtractValueTransformer, { ValueHolder } from "./testImpls/ExtractValueTransformer";
+import ExtractValueTransformer, {
+  ValueHolder,
+} from "./testImpls/ExtractValueTransformer";
 
 describe("CollectionUtils", () => {
   describe("#select()", () => {
@@ -21,14 +23,20 @@ describe("CollectionUtils", () => {
   describe("#selectRejected()", () => {
     it("should handle an empty input array", () => {
       const predicate = new ContainsExtensionPredicate("!");
-      const result: Array<string> = CollectionUtils.selectRejected([], predicate);
+      const result: Array<string> = CollectionUtils.selectRejected(
+        [],
+        predicate
+      );
       expect(result).toBeArrayOfSize(0);
     });
 
     it("should return elements that do not match a Predicate", () => {
       const predicate = new ContainsExtensionPredicate("!");
       const input = ["one", "two!", "three!", "four"];
-      const result: Array<string> = CollectionUtils.selectRejected(input, predicate);
+      const result: Array<string> = CollectionUtils.selectRejected(
+        input,
+        predicate
+      );
       expect(result).toStrictEqual(["one", "four"]);
     });
   });
@@ -42,11 +50,14 @@ describe("CollectionUtils", () => {
     });
 
     it("should return an array of transformed values", () => {
-      const input: Array<ValueHolder> = [{
-        value: "hi"
-      }, {
-        value: "world"
-      }];
+      const input: Array<ValueHolder> = [
+        {
+          value: "hi",
+        },
+        {
+          value: "world",
+        },
+      ];
       const result = CollectionUtils.transform(input, transformer);
       expect(result).toStrictEqual(["hi", "world"]);
     });

--- a/test/collectionUtils/core/TransformedPredicate.test.ts
+++ b/test/collectionUtils/core/TransformedPredicate.test.ts
@@ -1,14 +1,19 @@
 import TransformedPredicate from "../../../src/collectionUtils/core/TransformedPredicate";
 import AppendTransformer from "../testImpls/AppendTransformer";
-import ContainsExtensionPredicate  from "../testImpls/ContainsExtensionPredicate";
-import ExtractValueTransformer, { ValueHolder }  from "../testImpls/ExtractValueTransformer";
+import ContainsExtensionPredicate from "../testImpls/ContainsExtensionPredicate";
+import ExtractValueTransformer, {
+  ValueHolder,
+} from "../testImpls/ExtractValueTransformer";
 
 describe("TransformedPredicate", () => {
   it("should transform an object before evaluating the predicate against it", () => {
     const transformer = new AppendTransformer("XXX");
     const predicate = new ContainsExtensionPredicate("XXX");
 
-    const transformedPredicate = new TransformedPredicate<string, string>(transformer, predicate);
+    const transformedPredicate = new TransformedPredicate<string, string>(
+      transformer,
+      predicate
+    );
     expect(transformedPredicate.evaluate("Something")).toBeTrue();
   });
 
@@ -16,7 +21,10 @@ describe("TransformedPredicate", () => {
     const transformer = new ExtractValueTransformer();
     const predicate = new ContainsExtensionPredicate("!");
 
-    const transformedPredicate = new TransformedPredicate<ValueHolder, string>(transformer, predicate);
+    const transformedPredicate = new TransformedPredicate<ValueHolder, string>(
+      transformer,
+      predicate
+    );
     expect(transformedPredicate.evaluate({ value: "Awesome" })).toBeFalse();
     expect(transformedPredicate.evaluate({ value: "Awesome!" })).toBeTrue();
   });

--- a/test/collectionUtils/testImpls/ContainsExtensionPredicate.ts
+++ b/test/collectionUtils/testImpls/ContainsExtensionPredicate.ts
@@ -1,7 +1,7 @@
 import Predicate from "../../../src/collectionUtils/core/Predicate";
 
 export default class ContainsExtensionPredicate extends Predicate<string> {
-  constructor(public extension: string){
+  constructor(public extension: string) {
     super();
   }
 

--- a/test/generateMongooseTypes.test.ts
+++ b/test/generateMongooseTypes.test.ts
@@ -1,39 +1,45 @@
-import {exec} from 'child_process';
+import { exec } from "child_process";
 import MongooseTypeGenerator from "../src/generators/MongooseTypeGenerator";
-import {entityCollection} from './fixture/entityCollectionMongoose.json'
+import { entityCollection } from "./fixture/entityCollectionMongoose.json";
 import EntityCollection from "../src/model/dataTypes/EntityCollection";
 
-describe('generateMongooseTypes', () => {
-  const modelDir = './test/mongoose';
+describe("generateMongooseTypes", () => {
+  const modelDir = "./test/mongoose";
   afterAll(() => {
     exec(`rm -rf ${modelDir}`);
   });
   beforeAll(() => {
     exec(`rm -rf ${modelDir}`);
   });
-  test('Should generate mongoose models successfully', async () => {
-    const collection = JSON.parse(JSON.stringify(entityCollection)) as EntityCollection;
+  test("Should generate mongoose models successfully", async () => {
+    const collection = JSON.parse(
+      JSON.stringify(entityCollection)
+    ) as EntityCollection;
     const result = await MongooseTypeGenerator(collection);
     expect(result.length).toEqual(collection.entities.length);
-    expect(result[0]).toContain('const AccountSchema = DomainResourceSchemaFunction({\n' +
-      '  identifier : [IdentifierSchema],\n' +
-      '  status : AccountStatusSchema,\n' +
-      '  type : CodeableConceptSchema,\n' +
-      '  name : String,\n' +
-      '  subject : [ReferenceSchema],\n' +
-      '  servicePeriod : PeriodSchema,\n' +
-      '  coverage : [AccountCoverageSchema],\n' +
-      '  owner : ReferenceSchema,\n' +
-      '  description : String,\n' +
-      '  guarantor : [AccountGuarantorSchema],\n' +
-      '  partOf : ReferenceSchema,\n' +
-      '  fhirTitle: { type: String, default: \'Account\' },\n' +
-      '});');
-    expect(result[0]).toContain('class Account extends mongoose.Document {\n' +
-      '  constructor(object) {\n' +
-      '    super(object, AccountSchema);\n' +
-      '    this._type = \'FHIR::Account\';\n' +
-      '  }\n' +
-      '}');
+    expect(result[0]).toContain(
+      "const AccountSchema = DomainResourceSchemaFunction({\n" +
+        "  identifier : [IdentifierSchema],\n" +
+        "  status : AccountStatusSchema,\n" +
+        "  type : CodeableConceptSchema,\n" +
+        "  name : String,\n" +
+        "  subject : [ReferenceSchema],\n" +
+        "  servicePeriod : PeriodSchema,\n" +
+        "  coverage : [AccountCoverageSchema],\n" +
+        "  owner : ReferenceSchema,\n" +
+        "  description : String,\n" +
+        "  guarantor : [AccountGuarantorSchema],\n" +
+        "  partOf : ReferenceSchema,\n" +
+        "  fhirTitle: { type: String, default: 'Account' },\n" +
+        "});"
+    );
+    expect(result[0]).toContain(
+      "class Account extends mongoose.Document {\n" +
+        "  constructor(object) {\n" +
+        "    super(object, AccountSchema);\n" +
+        "    this._type = 'FHIR::Account';\n" +
+        "  }\n" +
+        "}"
+    );
   });
 });

--- a/test/model/dataTypes/EntityMetadata.test.ts
+++ b/test/model/dataTypes/EntityMetadata.test.ts
@@ -3,7 +3,11 @@ import EntityMetadata from "../../../src/model/dataTypes/EntityMetadata";
 describe("EntityMetadata", () => {
   describe("constructor", () => {
     it("should initialize EntityMetadata variables", () => {
-      const result = new EntityMetadata("namespace", "typeName", "parentTypeName");
+      const result = new EntityMetadata(
+        "namespace",
+        "typeName",
+        "parentTypeName"
+      );
       expect(result.namespace).toBe("namespace");
       expect(result.originalTypeName).toBe("typeName");
       expect(result.parentTypeName).toBe("parentTypeName");
@@ -12,7 +16,11 @@ describe("EntityMetadata", () => {
 
   describe("clone", () => {
     it("should create an deep copy of the metadata", () => {
-      const original = new EntityMetadata("namespace", "typeName", "parentTypeName");
+      const original = new EntityMetadata(
+        "namespace",
+        "typeName",
+        "parentTypeName"
+      );
       const result = original.clone();
       expect(result).not.toBe(original);
       expect(result.namespace).toBe("namespace");

--- a/test/model/dataTypes/FilePath.test.ts
+++ b/test/model/dataTypes/FilePath.test.ts
@@ -26,7 +26,9 @@ describe("FilePath", () => {
       expect(() => {
         FilePath.getInstance("someString.txt");
         FilePath.getInstance("SomeString.txt");
-      }).toThrow("FilePath \"SomeString.txt\" cannot overwrite equivalent file \"someString.txt\"");
+      }).toThrow(
+        'FilePath "SomeString.txt" cannot overwrite equivalent file "someString.txt"'
+      );
     });
   });
 
@@ -41,7 +43,10 @@ describe("FilePath", () => {
     });
 
     it("should handle duplicates", () => {
-      const arr = [FilePath.getInstance("./same"), FilePath.getInstance("./same")];
+      const arr = [
+        FilePath.getInstance("./same"),
+        FilePath.getInstance("./same"),
+      ];
       expect(FilePath.sortFilePaths(arr)).toBe(arr);
     });
 
@@ -50,7 +55,11 @@ describe("FilePath", () => {
       const bravo = FilePath.getInstance("./Bravo");
       const charlie = FilePath.getInstance("./charlie");
       const arr = [alpha, charlie, bravo];
-      expect(FilePath.sortFilePaths(arr)).toStrictEqual([alpha, bravo, charlie]);
+      expect(FilePath.sortFilePaths(arr)).toStrictEqual([
+        alpha,
+        bravo,
+        charlie,
+      ]);
     });
   });
 

--- a/test/preprocessors/MongoosePreprocessor.test.ts
+++ b/test/preprocessors/MongoosePreprocessor.test.ts
@@ -21,6 +21,8 @@ describe("MongoosePreprocessor", () => {
   });
 
   it("should do nothing extra for now", () => {
-    expect(preprocessor.preprocess(entityCollection)).not.toBe(entityCollection);
+    expect(preprocessor.preprocess(entityCollection)).not.toBe(
+      entityCollection
+    );
   });
 });

--- a/test/preprocessors/TypeScriptPreprocessor.test.ts
+++ b/test/preprocessors/TypeScriptPreprocessor.test.ts
@@ -21,6 +21,8 @@ describe("TypeScriptPreprocessor", () => {
   });
 
   it("should do nothing extra for now", () => {
-    expect(preprocessor.preprocess(entityCollection)).not.toBe(entityCollection);
+    expect(preprocessor.preprocess(entityCollection)).not.toBe(
+      entityCollection
+    );
   });
 });

--- a/test/templates/helpers/templateMongooseHelpers.test.ts
+++ b/test/templates/helpers/templateMongooseHelpers.test.ts
@@ -66,5 +66,4 @@ describe("templateMongooseHelpers", () => {
       expect(eq("one", "two")).toBeFalse();
     });
   });
-
 });


### PR DESCRIPTION
There are two commits- the first is from Prettier reformatting code. 
The second updates Mongoid's transform_json to call the super class' transform_json in order to initialize the inherited members