### PR TITLE
MAT-1389: Treat ValueSet types as primitive FHIR.codes

### DIFF
--- a/src/collectionUtils/InlineValueSetTypePredicate.ts
+++ b/src/collectionUtils/InlineValueSetTypePredicate.ts
@@ -13,7 +13,12 @@ import EntityDefinition from "../model/dataTypes/EntityDefinition";
 export default class InlineValueSetTypePredicate
   implements Predicate<EntityDefinition> {
   evaluate(input: EntityDefinition): boolean {
-    const { parentDataType, memberVariables } = input;
+    const { dataType, parentDataType, memberVariables } = input;
+    // Must not already be primitive
+    if (dataType.primitive) {
+      return false;
+    }
+
     // Must extend FHIR.Element
     if (
       !parentDataType ||

--- a/src/collectionUtils/InlineValueSetTypePredicate.ts
+++ b/src/collectionUtils/InlineValueSetTypePredicate.ts
@@ -1,0 +1,40 @@
+import Predicate from "./core/Predicate";
+import EntityDefinition from "../model/dataTypes/EntityDefinition";
+
+/**
+ * This predicate looks for types that should have extended FHIR.code
+ * in the modelinfo.xml file. A future fix to the modelinfo.xml
+ * should make this predicate unnecessary.
+ *
+ * The criteria is any EntityDefinition that:
+ *  - extends FHIR.Element
+ *  - has a single MemberVariable named "value" of type System.string
+ */
+export default class InlineValueSetTypePredicate
+  implements Predicate<EntityDefinition> {
+  evaluate(input: EntityDefinition): boolean {
+    const { parentDataType, memberVariables } = input;
+    // Must extend FHIR.Element
+    if (
+      !parentDataType ||
+      parentDataType.namespace !== "FHIR" ||
+      parentDataType.normalizedName !== "Element"
+    ) {
+      return false;
+    }
+
+    // Must have a single memberVariable
+    if (memberVariables.length !== 1) {
+      return false;
+    }
+
+    const [member] = memberVariables;
+
+    // Single member must be a System.String named "value"
+    return !(
+      member.variableName !== "value" ||
+      !member.dataType.systemType ||
+      member.dataType.normalizedName !== "String"
+    );
+  }
+}

--- a/src/collectionUtils/InlineValueSetTypeTransformer.ts
+++ b/src/collectionUtils/InlineValueSetTypeTransformer.ts
@@ -1,0 +1,36 @@
+import Transformer from "./core/Transformer";
+import EntityDefinition from "../model/dataTypes/EntityDefinition";
+import FilePath from "../model/dataTypes/FilePath";
+import DataType from "../model/dataTypes/DataType";
+import EntityImports from "../model/dataTypes/EntityImports";
+
+/**
+ * This transformer addresses a bug in the modelinfo.xml file.
+ * ValueSet types, which should have extended FHIR.code, do not.
+ * This transformer modifies them appropriately.
+ */
+export default class InlineValueSetTypeTransformer
+  implements Transformer<EntityDefinition, EntityDefinition> {
+  constructor(public baseDir: FilePath) {}
+
+  transform(input: EntityDefinition): EntityDefinition {
+    const { collectionName, dataType, metadata } = input;
+
+    const fhirCode = DataType.getInstance("FHIR", "code", this.baseDir);
+
+    // Change imports to only import FHIR.code
+    const newImports = new EntityImports([fhirCode]);
+
+    // Convert data type to primitive
+    DataType.convertTypeToPrimitive(dataType);
+
+    return new EntityDefinition(
+      metadata,
+      dataType,
+      fhirCode, // new parent
+      [], // remove members
+      newImports, // new imports
+      collectionName
+    );
+  }
+}

--- a/src/model/dataTypes/DataType.ts
+++ b/src/model/dataTypes/DataType.ts
@@ -111,6 +111,10 @@ export default class DataType {
     return newSystemType;
   }
 
+  public static clearCache(): void {
+    DataType.cache = {};
+  }
+
   private constructor(
     public readonly namespace: string,
     public readonly typeName: string,

--- a/src/model/dataTypes/DataType.ts
+++ b/src/model/dataTypes/DataType.ts
@@ -78,6 +78,16 @@ export default class DataType {
     return newDataType;
   }
 
+  /**
+   * Hopefully this can be deleted after the modelinfo fix for inlined ValueSet types
+   * @param type
+   */
+  public static convertTypeToPrimitive(type: DataType): DataType {
+    // eslint-disable-next-line no-param-reassign
+    type.primitive = true;
+    return type;
+  }
+
   private static parseSystemTypes(typeName: string): DataType {
     const fullPath = FilePath.getInstance(`${__dirname}/system/${typeName}`);
 
@@ -107,6 +117,6 @@ export default class DataType {
     public readonly path: FilePath,
     public readonly systemType: boolean,
     public readonly normalizedName: string,
-    public readonly primitive: boolean
+    public primitive: boolean // This should be readonly after the modelinfo fix
   ) {}
 }

--- a/src/preprocessors/BasePreprocessor.ts
+++ b/src/preprocessors/BasePreprocessor.ts
@@ -6,8 +6,12 @@ import TransformedPredicate from "../collectionUtils/core/TransformedPredicate";
 import ExtractDataTypeTransformer from "../collectionUtils/ExtractDataTypeTransformer";
 import BlacklistedTypesPredicate from "../collectionUtils/BlacklistedTypesPredicate";
 import AddResourceTypeFieldTransformer from "../collectionUtils/AddResourceTypeFieldTransformer";
+import InlineValueSetTypeTransformer from "../collectionUtils/InlineValueSetTypeTransformer";
+import InlineValueSetTypePredicate from "../collectionUtils/InlineValueSetTypePredicate";
 import Predicate from "../collectionUtils/core/Predicate";
 import Transformer from "../collectionUtils/core/Transformer";
+import IfTransformer from "../collectionUtils/core/IfTransformer";
+import NOPTransformer from "../collectionUtils/core/NOPTransformer";
 import ModifyElementTypeTransformer from "../collectionUtils/ModifyElementTypeTransformer";
 import DataType from "../model/dataTypes/DataType";
 import EntityImports from "../model/dataTypes/EntityImports";
@@ -43,6 +47,17 @@ export default class BaseProcessor implements Preprocessor {
     let result: EntityCollection = entityCollection.selectRejected(
       this.blacklistPredicate
     );
+
+    // Inline ValueSet types
+    const inlineValueSetTypeTransformer = new IfTransformer<
+      EntityDefinition,
+      EntityDefinition
+    >(
+      new InlineValueSetTypePredicate(),
+      new InlineValueSetTypeTransformer(entityCollection.baseDir),
+      new NOPTransformer()
+    );
+    result = result.transform(inlineValueSetTypeTransformer);
 
     // Add resourceType field to Resource entity
     result = result.transform(this.addResourceTypeTransformer);

--- a/test/collectionUtils/InlineValueSetTypePredicate.test.ts
+++ b/test/collectionUtils/InlineValueSetTypePredicate.test.ts
@@ -1,0 +1,81 @@
+import EntityDefinitionBuilder from "../model/dataTypes/EntityDefinitionBuilder";
+import EntityDefinition from "../../src/model/dataTypes/EntityDefinition";
+import InlineValueSetTypePredicate from "../../src/collectionUtils/InlineValueSetTypePredicate";
+import DataType from "../../src/model/dataTypes/DataType";
+import MemberVariable from "../../src/model/dataTypes/MemberVariable";
+
+describe("InlineValueSetTypePredicate", () => {
+  let predicate: InlineValueSetTypePredicate;
+  let entityDefinitionBuilder: EntityDefinitionBuilder;
+  let entity: EntityDefinition;
+  let elementType: DataType;
+  let otherType: DataType;
+  let wrongNs: DataType;
+  let systemStringType: DataType;
+  let systemDateType: DataType;
+  let valueMember: MemberVariable;
+  let wrongNameMember: MemberVariable;
+  let wrongTypeMember: MemberVariable;
+  let wrongSystemTypeMember: MemberVariable;
+
+  beforeEach(() => {
+    predicate = new InlineValueSetTypePredicate();
+
+    elementType = DataType.getInstance("FHIR", "Element", "/tmp");
+    otherType = DataType.getInstance("WrongNS", "Element", "/tmp");
+    wrongNs = DataType.getInstance("FHIR", "OtherType", "/tmp");
+    systemStringType = DataType.getInstance("System", "String", "/tmp");
+    systemDateType = DataType.getInstance("System", "Date", "/tmp");
+
+    entityDefinitionBuilder = new EntityDefinitionBuilder();
+    valueMember = new MemberVariable(systemStringType, "value");
+    wrongNameMember = new MemberVariable(systemStringType, "notValue");
+    wrongTypeMember = new MemberVariable(wrongNs, "value");
+    wrongSystemTypeMember = new MemberVariable(systemDateType, "value");
+    entityDefinitionBuilder.parentType = elementType;
+    entityDefinitionBuilder.memberVariables = [valueMember];
+  });
+
+  it("should return true if entity extends FHIR.Element and has single value member", () => {
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeTrue();
+  });
+
+  it("should return false if entity has no parent type", () => {
+    entityDefinitionBuilder.parentType = null;
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+
+  it("should return false if entity's parent type is not FHIR.Element", () => {
+    entityDefinitionBuilder.parentType = wrongNs;
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+
+    entityDefinitionBuilder.parentType = otherType;
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+
+  it("should return false if entity has more than one member variable", () => {
+    entityDefinitionBuilder.memberVariables = [valueMember, wrongNameMember];
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+
+  it("should return false if entity's member is not named 'value'", () => {
+    entityDefinitionBuilder.memberVariables = [wrongNameMember];
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+
+  it("should return false if entity's member a System.String", () => {
+    entityDefinitionBuilder.memberVariables = [wrongTypeMember];
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+
+    entityDefinitionBuilder.memberVariables = [wrongSystemTypeMember];
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+});

--- a/test/collectionUtils/InlineValueSetTypePredicate.test.ts
+++ b/test/collectionUtils/InlineValueSetTypePredicate.test.ts
@@ -41,6 +41,16 @@ describe("InlineValueSetTypePredicate", () => {
     expect(predicate.evaluate(entity)).toBeTrue();
   });
 
+  it("should return false if entity is already primitive", () => {
+    entityDefinitionBuilder.dataType = DataType.getInstance(
+      "FHIR",
+      "string",
+      "/tmp"
+    );
+    entity = entityDefinitionBuilder.buildEntityDefinition();
+    expect(predicate.evaluate(entity)).toBeFalse();
+  });
+
   it("should return false if entity has no parent type", () => {
     entityDefinitionBuilder.parentType = null;
     entity = entityDefinitionBuilder.buildEntityDefinition();

--- a/test/collectionUtils/InlineValueSetTypeTransformer.test.ts
+++ b/test/collectionUtils/InlineValueSetTypeTransformer.test.ts
@@ -1,0 +1,62 @@
+import InlineValueSetTypeTransformer from "../../src/collectionUtils/InlineValueSetTypeTransformer";
+import EntityDefinition from "../../src/model/dataTypes/EntityDefinition";
+import EntityDefinitionBuilder from "../model/dataTypes/EntityDefinitionBuilder";
+import DataType from "../../src/model/dataTypes/DataType";
+import EntityImports from "../../src/model/dataTypes/EntityImports";
+import MemberVariable from "../../src/model/dataTypes/MemberVariable";
+import FilePath from "../../src/model/dataTypes/FilePath";
+
+describe("InlineValueSetTypeTransformer", () => {
+  let transformer: InlineValueSetTypeTransformer;
+  let valueSetEntity: EntityDefinition;
+  let entityType: DataType;
+
+  beforeEach(() => {
+    transformer = new InlineValueSetTypeTransformer(
+      FilePath.getInstance("/tmp")
+    );
+    const builder = new EntityDefinitionBuilder();
+
+    const elementType = DataType.getInstance("FHIR", "Element", "/tmp");
+    entityType = DataType.getInstance("FHIR", "TestEntity", "/tmp");
+    const iEntityType = DataType.getInstance("FHIR", "ITestEntity", "/tmp");
+    const systemString = DataType.getInstance("System", "String", "/tmp");
+
+    const valueMember = new MemberVariable(systemString, "value");
+
+    builder.parentType = elementType;
+    builder.imports = new EntityImports([elementType, iEntityType]);
+    builder.dataType = entityType;
+    builder.memberVariables = [valueMember];
+    valueSetEntity = builder.buildEntityDefinition();
+  });
+
+  it("should return a new instance", () => {
+    const result = transformer.transform(valueSetEntity);
+    expect(result).not.toBe(valueSetEntity);
+  });
+
+  it("should only import FHIR.code", () => {
+    const result = transformer.transform(valueSetEntity);
+    expect(result.imports.dataTypes).toBeArrayOfSize(1);
+    expect(result.imports.dataTypes[0].namespace).toBe("FHIR");
+    expect(result.imports.dataTypes[0].normalizedName).toBe("PrimitiveCode");
+  });
+
+  it("should extend FHIR.code", () => {
+    const result = transformer.transform(valueSetEntity);
+    expect(result.parentDataType).toBeDefined();
+    expect(result.parentDataType?.namespace).toBe("FHIR");
+    expect(result.parentDataType?.normalizedName).toBe("PrimitiveCode");
+  });
+
+  it("should no member variables", () => {
+    const result = transformer.transform(valueSetEntity);
+    expect(result.memberVariables).toBeArrayOfSize(0);
+  });
+
+  it("should convert the entity's DataType to primitive", () => {
+    transformer.transform(valueSetEntity);
+    expect(entityType.primitive).toBeTrue();
+  });
+});

--- a/test/model/dataTypes/DataType.test.ts
+++ b/test/model/dataTypes/DataType.test.ts
@@ -82,4 +82,24 @@ describe("DataType", () => {
       expect(DataType.getInstance("System", "Time", "/tmp")).toBe(SystemTime);
     });
   });
+
+  describe("#convertTypeToPrimitive()", () => {
+    it("should set the specified type's primitive flag to true", () => {
+      const originalType = DataType.getInstance("NewNS", "NewType", "/tmp");
+      expect(originalType.primitive).toBeFalse();
+
+      const result = DataType.convertTypeToPrimitive(originalType);
+      expect(result).toBe(originalType);
+      expect(result.path).toBe(originalType.path);
+      expect(result.normalizedName).toBe(originalType.normalizedName);
+      expect(result.systemType).toBe(originalType.systemType);
+      expect(result.typeName).toBe(originalType.typeName);
+      expect(result.namespace).toBe(originalType.namespace);
+      expect(result.primitive).toBeTrue();
+
+      const cachedType = DataType.getInstance("NewNS", "NewType", "/tmp");
+      expect(cachedType).toBe(result);
+      expect(cachedType.primitive).toBeTrue();
+    });
+  });
 });

--- a/test/preprocessors/BasePreprocessor.test.ts
+++ b/test/preprocessors/BasePreprocessor.test.ts
@@ -18,6 +18,7 @@ describe("BasePreprocessor", () => {
   let entityCollection: EntityCollection;
 
   beforeEach(() => {
+    DataType.clearCache();
     entityBuilder = new EntityDefinitionBuilder();
     preprocessor = new BasePreprocessor();
     entityBuilder.dataType = DataType.getInstance("FHIR", "Resource", "/tmp");

--- a/test/preprocessors/BasePreprocessor.test.ts
+++ b/test/preprocessors/BasePreprocessor.test.ts
@@ -4,25 +4,27 @@ import EntityDefinition from "../../src/model/dataTypes/EntityDefinition";
 import EntityCollection from "../../src/model/dataTypes/EntityCollection";
 import FilePath from "../../src/model/dataTypes/FilePath";
 import Predicate from "../../src/collectionUtils/core/Predicate";
-import Transformer from "../../src/collectionUtils/core/Transformer";
 import DataType from "../../src/model/dataTypes/DataType";
 import ModifyElementTypeTransformer from "../../src/collectionUtils/ModifyElementTypeTransformer";
 import AddResourceTypeFieldTransformer from "../../src/collectionUtils/AddResourceTypeFieldTransformer";
+import MemberVariable from "../../src/model/dataTypes/MemberVariable";
 
 describe("BasePreprocessor", () => {
   let entityBuilder: EntityDefinitionBuilder;
   let preprocessor: BasePreprocessor;
   let allowedUnitsDef: EntityDefinition;
-  let otherEntity: EntityDefinition;
+  let resourceEntity: EntityDefinition;
+  let elementEntity: EntityDefinition;
   let entityCollection: EntityCollection;
-  let mockResourceTransform: (input: EntityDefinition) => EntityDefinition;
-  let mockElementTransform: (input: EntityDefinition) => EntityDefinition;
-  let mockEvaluate: (input: EntityDefinition) => boolean;
 
   beforeEach(() => {
     entityBuilder = new EntityDefinitionBuilder();
     preprocessor = new BasePreprocessor();
-    otherEntity = entityBuilder.buildEntityDefinition();
+    entityBuilder.dataType = DataType.getInstance("FHIR", "Resource", "/tmp");
+    resourceEntity = entityBuilder.buildEntityDefinition();
+
+    entityBuilder.dataType = DataType.getInstance("FHIR", "Element", "/tmp");
+    elementEntity = entityBuilder.buildEntityDefinition();
 
     entityBuilder = new EntityDefinitionBuilder();
     entityBuilder.dataType = DataType.getInstance(
@@ -32,14 +34,21 @@ describe("BasePreprocessor", () => {
     );
     allowedUnitsDef = entityBuilder.buildEntityDefinition();
 
+    entityBuilder = new EntityDefinitionBuilder();
+    const valueSetType = DataType.getInstance("FHIR", "ValueSetType", "/tmp");
+    const elementType = DataType.getInstance("FHIR", "Element", "/tmp");
+    const systemString = DataType.getInstance("System", "String", "/tmp");
+    const valueMember = new MemberVariable(systemString, "value");
+
+    entityBuilder.dataType = valueSetType;
+    entityBuilder.parentType = elementType;
+    entityBuilder.memberVariables = [valueMember];
+    const valueSetEntity = entityBuilder.buildEntityDefinition();
+
     entityCollection = new EntityCollection(
-      [otherEntity, allowedUnitsDef],
+      [resourceEntity, elementEntity, allowedUnitsDef, valueSetEntity],
       FilePath.getInstance("/tmp")
     );
-
-    mockResourceTransform = jest.fn().mockReturnValue(entityCollection);
-    mockElementTransform = jest.fn().mockReturnValue(entityCollection);
-    mockEvaluate = jest.fn().mockReturnValue(false);
   });
 
   describe("constructor", () => {
@@ -64,64 +73,61 @@ describe("BasePreprocessor", () => {
   });
 
   describe("#preprocess()", () => {
-    beforeEach(() => {
-      const mockBlacklistPredicate: Predicate<EntityDefinition> = {
-        evaluate: mockEvaluate,
-      };
-
-      const mockResourceTransformer: Transformer<
-        EntityDefinition,
-        EntityDefinition
-      > = {
-        transform: mockResourceTransform,
-      };
-
-      const mockElementTransformer: Transformer<
-        EntityDefinition,
-        EntityDefinition
-      > = {
-        transform: mockElementTransform,
-      };
-
-      preprocessor.blacklistPredicate = mockBlacklistPredicate;
-      preprocessor.addResourceTypeTransformer = mockResourceTransformer;
-      preprocessor.modifyElementTypeTransformer = mockElementTransformer;
-    });
-
     it("should filter out blacklisted EntityDefinitions", () => {
       const result = preprocessor.preprocess(entityCollection);
       expect(result).not.toBe(entityCollection);
-      expect(result.entities).toBeArrayOfSize(3);
-      expect(mockEvaluate).toHaveBeenCalledTimes(2);
+      expect(result.entities).toBeArrayOfSize(4);
+      expect(result.entities[0].dataType.normalizedName).toBe("Resource");
+      expect(result.entities[1].dataType.normalizedName).toBe("Element");
+      expect(result.entities[2].dataType.normalizedName).toBe("ValueSetType");
+      expect(result.entities[3].dataType.normalizedName).toBe("Type");
     });
 
     it("should add a resourceType field to Resource entities", () => {
-      preprocessor.preprocess(entityCollection);
-      expect(mockResourceTransform).toHaveBeenCalledTimes(2);
+      const result = preprocessor.preprocess(entityCollection);
+      expect(result.entities[0].dataType.normalizedName).toBe("Resource")
+      expect(result.entities[0].memberVariables).toBeArrayOfSize(3);
+      expect(result.entities[0].memberVariables[2].variableName).toBe("resourceType");
+
     });
 
     it("should modify the Element type to extend FHIR.Type", () => {
-      preprocessor.preprocess(entityCollection);
-      expect(mockElementTransform).toHaveBeenCalledTimes(2);
+      const result = preprocessor.preprocess(entityCollection);
+      expect(result.entities[1].parentDataType?.normalizedName).toBe("Type");
     });
 
     it("should create and add the FHIR.Type definition to the collection", () => {
       const result: EntityCollection = preprocessor.preprocess(
         entityCollection
       );
-      expect(result.entities).toBeArrayOfSize(3);
-      expect(result.entities[2].parentDataType).toBeNull();
-      expect(result.entities[2].dataType.namespace).toBe("FHIR");
-      expect(result.entities[2].dataType.typeName).toBe("Type");
-      expect(result.entities[2].dataType.path.toString()).toBe(
+      expect(result.entities).toBeArrayOfSize(4);
+      const fhirType = result.entities[3];
+      expect(fhirType.parentDataType).toBeNull();
+      expect(fhirType.dataType.namespace).toBe("FHIR");
+      expect(fhirType.dataType.typeName).toBe("Type");
+      expect(fhirType.dataType.path.toString()).toBe(
         `${entityCollection.baseDir.toString()}/FHIR/Type`
       );
-      expect(result.entities[2].metadata.namespace).toBe("FHIR");
-      expect(result.entities[2].metadata.originalTypeName).toBe("Type");
-      expect(result.entities[2].metadata.parentTypeName).toBe("");
-      expect(result.entities[2].imports.dataTypes).toBeArrayOfSize(0);
-      expect(result.entities[2].parentDataType).toBeNull();
-      expect(result.entities[2].memberVariables).toBeArrayOfSize(0);
+      expect(fhirType.metadata.namespace).toBe("FHIR");
+      expect(fhirType.metadata.originalTypeName).toBe("Type");
+      expect(fhirType.metadata.parentTypeName).toBe("");
+      expect(fhirType.imports.dataTypes).toBeArrayOfSize(0);
+      expect(fhirType.parentDataType).toBeNull();
+      expect(fhirType.memberVariables).toBeArrayOfSize(0);
+    });
+
+    it("should transform the valueSet type", () => {
+      const result: EntityCollection = preprocessor.preprocess(
+        entityCollection
+      );
+      expect(result.entities).toBeArrayOfSize(4);
+      const transformedEntity = result.entities[2];
+      expect(transformedEntity.dataType.normalizedName).toBe("ValueSetType");
+      expect(transformedEntity.dataType.primitive).toBeTrue();
+      expect(transformedEntity.memberVariables).toBeArrayOfSize(0);
+      expect(transformedEntity.imports.dataTypes).toBeArrayOfSize(1);
+      expect(transformedEntity.imports.dataTypes[0].normalizedName).toBe("PrimitiveCode");
+      expect(transformedEntity.parentDataType?.normalizedName).toBe("PrimitiveCode");
     });
   });
 });


### PR DESCRIPTION
When we encounter a ValueSet type like AddressUse, we inline it to extend FHIR.code and treat it as a primitive.


