### PR TITLE
MAT-1567: TypeScript models clone() method and JSON parsing bug fix

### DIFF
--- a/src/templates/typescript/classes/classTemplate.ts
+++ b/src/templates/typescript/classes/classTemplate.ts
@@ -131,7 +131,20 @@ export class {{ dataType.normalizedName }}{{# if parentDataType }} extends {{ pa
     return result;
   }
 {{/ unless }}
-  
+
+  public clone(): {{ dataType.normalizedName }} {
+  {{# if dataType.primitive }}
+    const result = new {{ dataType.normalizedName }}();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  {{ else }}
+    return {{ dataType.normalizedName }}.parse(this.toJSON());
+  {{/ if }}
+  }
+
   public getTypeName(): string {
     return "{{ dataType.normalizedName }}";
   }

--- a/src/templates/typescript/classes/parseChoiceMemberTemplate.ts
+++ b/src/templates/typescript/classes/parseChoiceMemberTemplate.ts
@@ -1,5 +1,5 @@
 export default `
-  if (json.{{ variableName }}{{ trimPrimitiveName dataType.normalizedName}}) {
+  if (json.{{ variableName }}{{ trimPrimitiveName dataType.normalizedName}} !== undefined) {
   {{# if dataType.systemType }}
     newInstance.{{ variableName }} = json.{{ variableName }}{{ trimPrimitiveName dataType.normalizedName}};
   {{ else }}

--- a/src/templates/typescript/classes/parseSingleMemberTemplate.ts
+++ b/src/templates/typescript/classes/parseSingleMemberTemplate.ts
@@ -1,5 +1,5 @@
 export default `
-  if (json.{{ variableName }}) {
+  if (json.{{ variableName }} !== undefined) {
   {{# if dataType.systemType }}
     newInstance.{{ variableName }} = json.{{ variableName }};
   {{ else }}

--- a/src/templates/typescript/classes/primitiveParseTemplate.ts
+++ b/src/templates/typescript/classes/primitiveParseTemplate.ts
@@ -14,7 +14,7 @@ export default `public static parsePrimitive(
     let newInstance: {{ dataType.normalizedName }};
 
     if (extension) {
-      newInstance = {{ parentDataType.normalizedName }}.parse(extension);
+      newInstance = {{ parentDataType.normalizedName }}.parse(extension, providedInstance);
     } else {
       newInstance = providedInstance;
     }

--- a/test/fixture/generatedTypeScript/classes/AddressType.ts
+++ b/test/fixture/generatedTypeScript/classes/AddressType.ts
@@ -22,7 +22,16 @@ export class AddressType extends PrimitiveCode {
     const castInput = input as AddressType;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "AddressType";
   }
-  
+
+  public clone(): AddressType {
+    const result = new AddressType();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "AddressType";
   }

--- a/test/fixture/generatedTypeScript/classes/BackboneElement.ts
+++ b/test/fixture/generatedTypeScript/classes/BackboneElement.ts
@@ -20,7 +20,7 @@ export class BackboneElement extends Element {
   ): BackboneElement {
     const newInstance: BackboneElement = Element.parse(json, providedInstance);
   
-    if (json.modifierExtension) {
+    if (json.modifierExtension !== undefined) {
       newInstance.modifierExtension = json.modifierExtension.map((x) => Extension.parse(x));
     }
     return newInstance;
@@ -40,7 +40,11 @@ export class BackboneElement extends Element {
 
     return result;
   }
-  
+
+  public clone(): BackboneElement {
+    return BackboneElement.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "BackboneElement";
   }

--- a/test/fixture/generatedTypeScript/classes/Bundle.ts
+++ b/test/fixture/generatedTypeScript/classes/Bundle.ts
@@ -20,7 +20,7 @@ export class Bundle extends Resource {
   ): Bundle {
     const newInstance: Bundle = Resource.parse(json, providedInstance);
   
-    if (json.entry) {
+    if (json.entry !== undefined) {
       newInstance.entry = json.entry.map((x) => BundleEntry.parse(x));
     }
     return newInstance;
@@ -40,7 +40,11 @@ export class Bundle extends Resource {
 
     return result;
   }
-  
+
+  public clone(): Bundle {
+    return Bundle.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Bundle";
   }

--- a/test/fixture/generatedTypeScript/classes/BundleEntry.ts
+++ b/test/fixture/generatedTypeScript/classes/BundleEntry.ts
@@ -20,7 +20,7 @@ export class BundleEntry extends BackboneElement {
   ): BundleEntry {
     const newInstance: BundleEntry = BackboneElement.parse(json, providedInstance);
   
-    if (json.resource) {
+    if (json.resource !== undefined) {
       newInstance.resource = Resource.parse(json.resource);
     }
     return newInstance;
@@ -40,7 +40,11 @@ export class BundleEntry extends BackboneElement {
 
     return result;
   }
-  
+
+  public clone(): BundleEntry {
+    return BundleEntry.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "BundleEntry";
   }

--- a/test/fixture/generatedTypeScript/classes/CodeableConcept.ts
+++ b/test/fixture/generatedTypeScript/classes/CodeableConcept.ts
@@ -24,10 +24,10 @@ export class CodeableConcept extends Element {
   ): CodeableConcept {
     const newInstance: CodeableConcept = Element.parse(json, providedInstance);
   
-    if (json.coding) {
+    if (json.coding !== undefined) {
       newInstance.coding = json.coding.map((x) => Coding.parse(x));
     }
-    if (json.text) {
+    if (json.text !== undefined) {
       newInstance.text = PrimitiveString.parsePrimitive(json.text, json._text);
     }
     return newInstance;
@@ -52,7 +52,11 @@ export class CodeableConcept extends Element {
 
     return result;
   }
-  
+
+  public clone(): CodeableConcept {
+    return CodeableConcept.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "CodeableConcept";
   }

--- a/test/fixture/generatedTypeScript/classes/Coding.ts
+++ b/test/fixture/generatedTypeScript/classes/Coding.ts
@@ -32,19 +32,19 @@ export class Coding extends Element {
   ): Coding {
     const newInstance: Coding = Element.parse(json, providedInstance);
   
-    if (json.system) {
+    if (json.system !== undefined) {
       newInstance.system = PrimitiveUri.parsePrimitive(json.system, json._system);
     }
-    if (json.version) {
+    if (json.version !== undefined) {
       newInstance.version = PrimitiveString.parsePrimitive(json.version, json._version);
     }
-    if (json.code) {
+    if (json.code !== undefined) {
       newInstance.code = PrimitiveCode.parsePrimitive(json.code, json._code);
     }
-    if (json.display) {
+    if (json.display !== undefined) {
       newInstance.display = PrimitiveString.parsePrimitive(json.display, json._display);
     }
-    if (json.userSelected) {
+    if (json.userSelected !== undefined) {
       newInstance.userSelected = PrimitiveBoolean.parsePrimitive(json.userSelected, json._userSelected);
     }
     return newInstance;
@@ -85,7 +85,11 @@ export class Coding extends Element {
 
     return result;
   }
-  
+
+  public clone(): Coding {
+    return Coding.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Coding";
   }

--- a/test/fixture/generatedTypeScript/classes/DomainResource.ts
+++ b/test/fixture/generatedTypeScript/classes/DomainResource.ts
@@ -24,13 +24,13 @@ export class DomainResource extends Resource {
   ): DomainResource {
     const newInstance: DomainResource = Resource.parse(json, providedInstance);
   
-    if (json.contained) {
+    if (json.contained !== undefined) {
       newInstance.contained = json.contained.map((x) => Resource.parse(x));
     }
-    if (json.extension) {
+    if (json.extension !== undefined) {
       newInstance.extension = json.extension.map((x) => Extension.parse(x));
     }
-    if (json.modifierExtension) {
+    if (json.modifierExtension !== undefined) {
       newInstance.modifierExtension = json.modifierExtension.map((x) => Extension.parse(x));
     }
     return newInstance;
@@ -58,7 +58,11 @@ export class DomainResource extends Resource {
 
     return result;
   }
-  
+
+  public clone(): DomainResource {
+    return DomainResource.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "DomainResource";
   }

--- a/test/fixture/generatedTypeScript/classes/Element.ts
+++ b/test/fixture/generatedTypeScript/classes/Element.ts
@@ -22,10 +22,10 @@ export class Element extends Type {
   ): Element {
     const newInstance: Element = Type.parse(json, providedInstance);
   
-    if (json.id) {
+    if (json.id !== undefined) {
       newInstance.id = json.id;
     }
-    if (json.extension) {
+    if (json.extension !== undefined) {
       newInstance.extension = json.extension.map((x) => Extension.parse(x));
     }
     return newInstance;
@@ -49,7 +49,11 @@ export class Element extends Type {
 
     return result;
   }
-  
+
+  public clone(): Element {
+    return Element.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Element";
   }

--- a/test/fixture/generatedTypeScript/classes/Extension.ts
+++ b/test/fixture/generatedTypeScript/classes/Extension.ts
@@ -42,67 +42,67 @@ export class Extension extends Element {
   ): Extension {
     const newInstance: Extension = Element.parse(json, providedInstance);
   
-    if (json.url) {
+    if (json.url !== undefined) {
       newInstance.url = PrimitiveUri.parsePrimitive(json.url, json._url);
     }
-    if (json.valueBase64Binary) {
+    if (json.valueBase64Binary !== undefined) {
       newInstance.value = PrimitiveBase64Binary.parsePrimitive(json.valueBase64Binary, json._valueBase64Binary);
     }
-    if (json.valueBoolean) {
+    if (json.valueBoolean !== undefined) {
       newInstance.value = PrimitiveBoolean.parsePrimitive(json.valueBoolean, json._valueBoolean);
     }
-    if (json.valueCanonical) {
+    if (json.valueCanonical !== undefined) {
       newInstance.value = PrimitiveCanonical.parsePrimitive(json.valueCanonical, json._valueCanonical);
     }
-    if (json.valueCode) {
+    if (json.valueCode !== undefined) {
       newInstance.value = PrimitiveCode.parsePrimitive(json.valueCode, json._valueCode);
     }
-    if (json.valueDate) {
+    if (json.valueDate !== undefined) {
       newInstance.value = PrimitiveDate.parsePrimitive(json.valueDate, json._valueDate);
     }
-    if (json.valueDateTime) {
+    if (json.valueDateTime !== undefined) {
       newInstance.value = PrimitiveDateTime.parsePrimitive(json.valueDateTime, json._valueDateTime);
     }
-    if (json.valueDecimal) {
+    if (json.valueDecimal !== undefined) {
       newInstance.value = PrimitiveDecimal.parsePrimitive(json.valueDecimal, json._valueDecimal);
     }
-    if (json.valueId) {
+    if (json.valueId !== undefined) {
       newInstance.value = PrimitiveId.parsePrimitive(json.valueId, json._valueId);
     }
-    if (json.valueInstant) {
+    if (json.valueInstant !== undefined) {
       newInstance.value = PrimitiveInstant.parsePrimitive(json.valueInstant, json._valueInstant);
     }
-    if (json.valueInteger) {
+    if (json.valueInteger !== undefined) {
       newInstance.value = PrimitiveInteger.parsePrimitive(json.valueInteger, json._valueInteger);
     }
-    if (json.valueMarkdown) {
+    if (json.valueMarkdown !== undefined) {
       newInstance.value = PrimitiveMarkdown.parsePrimitive(json.valueMarkdown, json._valueMarkdown);
     }
-    if (json.valueOid) {
+    if (json.valueOid !== undefined) {
       newInstance.value = PrimitiveOid.parsePrimitive(json.valueOid, json._valueOid);
     }
-    if (json.valuePositiveInt) {
+    if (json.valuePositiveInt !== undefined) {
       newInstance.value = PrimitivePositiveInt.parsePrimitive(json.valuePositiveInt, json._valuePositiveInt);
     }
-    if (json.valueString) {
+    if (json.valueString !== undefined) {
       newInstance.value = PrimitiveString.parsePrimitive(json.valueString, json._valueString);
     }
-    if (json.valueTime) {
+    if (json.valueTime !== undefined) {
       newInstance.value = PrimitiveTime.parsePrimitive(json.valueTime, json._valueTime);
     }
-    if (json.valueUnsignedInt) {
+    if (json.valueUnsignedInt !== undefined) {
       newInstance.value = PrimitiveUnsignedInt.parsePrimitive(json.valueUnsignedInt, json._valueUnsignedInt);
     }
-    if (json.valueUri) {
+    if (json.valueUri !== undefined) {
       newInstance.value = PrimitiveUri.parsePrimitive(json.valueUri, json._valueUri);
     }
-    if (json.valueUrl) {
+    if (json.valueUrl !== undefined) {
       newInstance.value = PrimitiveUrl.parsePrimitive(json.valueUrl, json._valueUrl);
     }
-    if (json.valueUuid) {
+    if (json.valueUuid !== undefined) {
       newInstance.value = PrimitiveUuid.parsePrimitive(json.valueUuid, json._valueUuid);
     }
-    if (json.valueCoding) {
+    if (json.valueCoding !== undefined) {
       newInstance.value = Coding.parse(json.valueCoding);
     }
     return newInstance;
@@ -256,7 +256,11 @@ export class Extension extends Element {
 
     return result;
   }
-  
+
+  public clone(): Extension {
+    return Extension.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Extension";
   }

--- a/test/fixture/generatedTypeScript/classes/KitchenSink.ts
+++ b/test/fixture/generatedTypeScript/classes/KitchenSink.ts
@@ -39,34 +39,34 @@ export class KitchenSink extends Element {
   ): KitchenSink {
     const newInstance: KitchenSink = Element.parse(json, providedInstance);
   
-    if (json.system) {
+    if (json.system !== undefined) {
       newInstance.system = json.system;
     }
-    if (json.url) {
+    if (json.url !== undefined) {
       newInstance.url = PrimitiveUrl.parsePrimitive(json.url, json._url);
     }
-    if (json.version) {
+    if (json.version !== undefined) {
       newInstance.version = PrimitiveString.parsePrimitive(json.version, json._version);
     }
-    if (json.singleCode) {
+    if (json.singleCode !== undefined) {
       newInstance.singleCode = CodeableConcept.parse(json.singleCode);
     }
-    if (json.coding) {
+    if (json.coding !== undefined) {
       newInstance.coding = json.coding.map((x) => Coding.parse(x));
     }
-    if (json.times) {
+    if (json.times !== undefined) {
       newInstance.times = json.times.map((x, i) => {
         const ext = json._times && json._times[i];
         return PrimitiveTime.parsePrimitive(x, ext);
       });
     }
-    if (json.optionsBoolean) {
+    if (json.optionsBoolean !== undefined) {
       newInstance.options = PrimitiveBoolean.parsePrimitive(json.optionsBoolean, json._optionsBoolean);
     }
-    if (json.optionsCanonical) {
+    if (json.optionsCanonical !== undefined) {
       newInstance.options = PrimitiveCanonical.parsePrimitive(json.optionsCanonical, json._optionsCanonical);
     }
-    if (json.optionsCoding) {
+    if (json.optionsCoding !== undefined) {
       newInstance.options = Coding.parse(json.optionsCoding);
     }
     return newInstance;
@@ -123,7 +123,11 @@ export class KitchenSink extends Element {
 
     return result;
   }
-  
+
+  public clone(): KitchenSink {
+    return KitchenSink.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "KitchenSink";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveBase64Binary.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveBase64Binary.ts
@@ -21,7 +21,7 @@ export class PrimitiveBase64Binary extends Element {
       let newInstance: PrimitiveBase64Binary;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveBase64Binary extends Element {
     const castInput = input as PrimitiveBase64Binary;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveBase64Binary";
   }
-  
+
+  public clone(): PrimitiveBase64Binary {
+    const result = new PrimitiveBase64Binary();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveBase64Binary";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveBoolean.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveBoolean.ts
@@ -21,7 +21,7 @@ export class PrimitiveBoolean extends Element {
       let newInstance: PrimitiveBoolean;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveBoolean extends Element {
     const castInput = input as PrimitiveBoolean;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveBoolean";
   }
-  
+
+  public clone(): PrimitiveBoolean {
+    const result = new PrimitiveBoolean();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveBoolean";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveCanonical.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveCanonical.ts
@@ -22,7 +22,16 @@ export class PrimitiveCanonical extends PrimitiveUri {
     const castInput = input as PrimitiveCanonical;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveCanonical";
   }
-  
+
+  public clone(): PrimitiveCanonical {
+    const result = new PrimitiveCanonical();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveCanonical";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveCode.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveCode.ts
@@ -22,7 +22,16 @@ export class PrimitiveCode extends PrimitiveString {
     const castInput = input as PrimitiveCode;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveCode";
   }
-  
+
+  public clone(): PrimitiveCode {
+    const result = new PrimitiveCode();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveCode";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveDate.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveDate.ts
@@ -21,7 +21,7 @@ export class PrimitiveDate extends Element {
       let newInstance: PrimitiveDate;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveDate extends Element {
     const castInput = input as PrimitiveDate;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveDate";
   }
-  
+
+  public clone(): PrimitiveDate {
+    const result = new PrimitiveDate();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveDate";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveDateTime.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveDateTime.ts
@@ -21,7 +21,7 @@ export class PrimitiveDateTime extends Element {
       let newInstance: PrimitiveDateTime;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveDateTime extends Element {
     const castInput = input as PrimitiveDateTime;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveDateTime";
   }
-  
+
+  public clone(): PrimitiveDateTime {
+    const result = new PrimitiveDateTime();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveDateTime";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveDecimal.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveDecimal.ts
@@ -21,7 +21,7 @@ export class PrimitiveDecimal extends Element {
       let newInstance: PrimitiveDecimal;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveDecimal extends Element {
     const castInput = input as PrimitiveDecimal;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveDecimal";
   }
-  
+
+  public clone(): PrimitiveDecimal {
+    const result = new PrimitiveDecimal();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveDecimal";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveId.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveId.ts
@@ -22,7 +22,16 @@ export class PrimitiveId extends PrimitiveString {
     const castInput = input as PrimitiveId;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveId";
   }
-  
+
+  public clone(): PrimitiveId {
+    const result = new PrimitiveId();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveId";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveInstant.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveInstant.ts
@@ -21,7 +21,7 @@ export class PrimitiveInstant extends Element {
       let newInstance: PrimitiveInstant;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveInstant extends Element {
     const castInput = input as PrimitiveInstant;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveInstant";
   }
-  
+
+  public clone(): PrimitiveInstant {
+    const result = new PrimitiveInstant();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveInstant";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveInteger.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveInteger.ts
@@ -21,7 +21,7 @@ export class PrimitiveInteger extends Element {
       let newInstance: PrimitiveInteger;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveInteger extends Element {
     const castInput = input as PrimitiveInteger;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveInteger";
   }
-  
+
+  public clone(): PrimitiveInteger {
+    const result = new PrimitiveInteger();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveInteger";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveMarkdown.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveMarkdown.ts
@@ -22,7 +22,16 @@ export class PrimitiveMarkdown extends PrimitiveString {
     const castInput = input as PrimitiveMarkdown;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveMarkdown";
   }
-  
+
+  public clone(): PrimitiveMarkdown {
+    const result = new PrimitiveMarkdown();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveMarkdown";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveOid.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveOid.ts
@@ -22,7 +22,16 @@ export class PrimitiveOid extends PrimitiveUri {
     const castInput = input as PrimitiveOid;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveOid";
   }
-  
+
+  public clone(): PrimitiveOid {
+    const result = new PrimitiveOid();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveOid";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitivePositiveInt.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitivePositiveInt.ts
@@ -22,7 +22,16 @@ export class PrimitivePositiveInt extends PrimitiveInteger {
     const castInput = input as PrimitivePositiveInt;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitivePositiveInt";
   }
-  
+
+  public clone(): PrimitivePositiveInt {
+    const result = new PrimitivePositiveInt();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitivePositiveInt";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveQuestion.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveQuestion.ts
@@ -22,7 +22,16 @@ export class PrimitiveQuestion extends PrimitiveString {
     const castInput = input as PrimitiveQuestion;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveQuestion";
   }
-  
+
+  public clone(): PrimitiveQuestion {
+    const result = new PrimitiveQuestion();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveQuestion";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveString.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveString.ts
@@ -21,7 +21,7 @@ export class PrimitiveString extends Element {
       let newInstance: PrimitiveString;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveString extends Element {
     const castInput = input as PrimitiveString;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveString";
   }
-  
+
+  public clone(): PrimitiveString {
+    const result = new PrimitiveString();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveString";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveTime.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveTime.ts
@@ -21,7 +21,7 @@ export class PrimitiveTime extends Element {
       let newInstance: PrimitiveTime;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveTime extends Element {
     const castInput = input as PrimitiveTime;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveTime";
   }
-  
+
+  public clone(): PrimitiveTime {
+    const result = new PrimitiveTime();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveTime";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveUnsignedInt.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveUnsignedInt.ts
@@ -22,7 +22,16 @@ export class PrimitiveUnsignedInt extends PrimitiveInteger {
     const castInput = input as PrimitiveUnsignedInt;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveUnsignedInt";
   }
-  
+
+  public clone(): PrimitiveUnsignedInt {
+    const result = new PrimitiveUnsignedInt();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveUnsignedInt";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveUri.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveUri.ts
@@ -21,7 +21,7 @@ export class PrimitiveUri extends Element {
       let newInstance: PrimitiveUri;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveUri extends Element {
     const castInput = input as PrimitiveUri;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveUri";
   }
-  
+
+  public clone(): PrimitiveUri {
+    const result = new PrimitiveUri();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveUri";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveUrl.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveUrl.ts
@@ -22,7 +22,16 @@ export class PrimitiveUrl extends PrimitiveUri {
     const castInput = input as PrimitiveUrl;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveUrl";
   }
-  
+
+  public clone(): PrimitiveUrl {
+    const result = new PrimitiveUrl();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveUrl";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveUuid.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveUuid.ts
@@ -22,7 +22,16 @@ export class PrimitiveUuid extends PrimitiveUri {
     const castInput = input as PrimitiveUuid;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveUuid";
   }
-  
+
+  public clone(): PrimitiveUuid {
+    const result = new PrimitiveUuid();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveUuid";
   }

--- a/test/fixture/generatedTypeScript/classes/PrimitiveXhtml.ts
+++ b/test/fixture/generatedTypeScript/classes/PrimitiveXhtml.ts
@@ -21,7 +21,7 @@ export class PrimitiveXhtml extends Element {
       let newInstance: PrimitiveXhtml;
   
       if (extension) {
-        newInstance = Element.parse(extension);
+        newInstance = Element.parse(extension, providedInstance);
       } else {
         newInstance = providedInstance;
       }
@@ -35,7 +35,16 @@ export class PrimitiveXhtml extends Element {
     const castInput = input as PrimitiveXhtml;
     return !!input && castInput.getTypeName && castInput.getTypeName() === "PrimitiveXhtml";
   }
-  
+
+  public clone(): PrimitiveXhtml {
+    const result = new PrimitiveXhtml();
+    const parentClone = super.clone();
+    result.id = parentClone.id;
+    result.extension = parentClone.extension;
+    result.value = this.value;
+    return result;
+  }
+
   public getTypeName(): string {
     return "PrimitiveXhtml";
   }

--- a/test/fixture/generatedTypeScript/classes/Resource.ts
+++ b/test/fixture/generatedTypeScript/classes/Resource.ts
@@ -39,13 +39,13 @@ export class Resource {
         }
       }
   
-    if (json.id) {
+    if (json.id !== undefined) {
       newInstance.id = json.id;
     }
-    if (json.language) {
+    if (json.language !== undefined) {
       newInstance.language = PrimitiveCode.parsePrimitive(json.language, json._language);
     }
-    if (json.resourceType) {
+    if (json.resourceType !== undefined) {
       newInstance.resourceType = json.resourceType;
     }
     return newInstance;
@@ -74,7 +74,11 @@ export class Resource {
 
     return result;
   }
-  
+
+  public clone(): Resource {
+    return Resource.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Resource";
   }

--- a/test/fixture/generatedTypeScript/classes/ResourceChild.ts
+++ b/test/fixture/generatedTypeScript/classes/ResourceChild.ts
@@ -21,7 +21,7 @@ export class ResourceChild extends Resource {
   ): ResourceChild {
     const newInstance: ResourceChild = Resource.parse(json, providedInstance);
   
-    if (json.boolVal) {
+    if (json.boolVal !== undefined) {
       newInstance.boolVal = PrimitiveBoolean.parsePrimitive(json.boolVal, json._boolVal);
     }
     return newInstance;
@@ -42,7 +42,11 @@ export class ResourceChild extends Resource {
 
     return result;
   }
-  
+
+  public clone(): ResourceChild {
+    return ResourceChild.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "ResourceChild";
   }

--- a/test/fixture/generatedTypeScript/classes/Type.ts
+++ b/test/fixture/generatedTypeScript/classes/Type.ts
@@ -29,7 +29,11 @@ export class Type {
 
     return result;
   }
-  
+
+  public clone(): Type {
+    return Type.parse(this.toJSON());
+  }
+
   public getTypeName(): string {
     return "Type";
   }

--- a/test/integration/Cloning.test.ts
+++ b/test/integration/Cloning.test.ts
@@ -1,0 +1,66 @@
+import {
+  KitchenSink,
+  PrimitiveUrl,
+  CodeableConcept,
+  PrimitiveString,
+  Coding,
+  PrimitiveCode,
+  PrimitiveTime,
+  PrimitiveBoolean,
+  IElement,
+} from "../fixture/generatedTypeScript/fhir";
+
+describe("Test cloning of the generated classes", () => {
+  let sink: KitchenSink;
+
+  beforeEach(() => {
+    sink = new KitchenSink();
+    sink.system = "theSystem";
+    sink.url = PrimitiveUrl.parsePrimitive("theUrl");
+    sink.singleCode = new CodeableConcept();
+    sink.singleCode.text = PrimitiveString.parsePrimitive("theCode");
+    const coding1 = new Coding();
+    coding1.code = PrimitiveCode.parsePrimitive("code1");
+    const coding2 = new Coding();
+    coding2.code = PrimitiveCode.parsePrimitive("code2");
+    sink.coding = [coding1, coding2];
+    sink.times = [
+      PrimitiveTime.parsePrimitive("time1"),
+      PrimitiveTime.parsePrimitive("time2"),
+    ];
+    sink.options = PrimitiveBoolean.parsePrimitive(false);
+  });
+
+  it("should create a new object, identical to the original", () => {
+    const newSink = sink.clone();
+    expect(newSink).not.toBe(sink);
+    expect(newSink).toEqual(sink);
+  });
+
+  it("should clone primitive objects", () => {
+    const extension: IElement = {
+      id: "theId",
+      extension: [
+        {
+          valueBoolean: false,
+        },
+      ],
+    };
+
+    const original = PrimitiveBoolean.parsePrimitive(false, extension);
+
+    const clone = original.clone();
+
+    expect(clone.value).toBeFalse();
+    expect(clone.id).toBe("theId");
+    expect(clone.extension).toBeArrayOfSize(1);
+    if (clone.extension) {
+      const extensionResult = clone.extension[0];
+      if (PrimitiveBoolean.isPrimitiveBoolean(extensionResult.value)) {
+        expect(extensionResult.value.value).toBeFalse();
+      } else {
+        expect.fail("Extension is wrong type");
+      }
+    }
+  });
+});

--- a/test/integration/JsonParsing.test.ts
+++ b/test/integration/JsonParsing.test.ts
@@ -177,4 +177,16 @@ describe("Testing the Parsing logic of a generated class", () => {
       expect(resourceChild.boolVal?.value).toBeTrue();
     }
   });
+
+  it("should parse falsy values correctly", () => {
+    const json: IResourceChild = {
+      resourceType: "ResourceChild",
+      boolVal: false,
+    };
+
+    const result: ResourceChild = ResourceChild.parse(json);
+
+    expect(result.resourceType).toBe("ResourceChild");
+    expect(result.boolVal?.value).toBeFalse();
+  });
 });


### PR DESCRIPTION
MAT-1567: Added a clone method to TypeScript models and fixed a bug where falsy values were not being parsed from incoming JSON