### PR TITLE
MAT-2229: Fixing constructor.name minification issue

### DIFF
--- a/src/templates/typescript/classes/classTemplate.ts
+++ b/src/templates/typescript/classes/classTemplate.ts
@@ -64,7 +64,7 @@ export class {{ dataType.normalizedName }}{{# if parentDataType }} extends {{ pa
 {{# if (eq dataType.normalizedName "Resource") }}
   constructor() {
     super();
-    this.resourceType = this.constructor.name;
+    this.resourceType = this.getTypeName();
   }
   
 {{/ if }}

--- a/test/ResourceType.test.ts
+++ b/test/ResourceType.test.ts
@@ -1,0 +1,23 @@
+import {
+  Resource,
+  DomainResource,
+  ResourceChild
+} from "./fixture/generatedTypeScript/fhir";
+
+describe("generated resourceType value, set in constructor or Resources", () => {
+
+  it("work for the base type Resource", () => {
+    const resource = new Resource();
+    expect(resource.resourceType).toBe("Resource");
+  });
+
+  it("work for the subclass DomainResource", () => {
+    const resource = new DomainResource();
+    expect(resource.resourceType).toBe("DomainResource");
+  });
+
+  it("work for the subclass ResourceChild", () => {
+    const resource = new ResourceChild();
+    expect(resource.resourceType).toBe("ResourceChild");
+  });
+});

--- a/test/fixture/generatedTypeScript/classes/Resource.ts
+++ b/test/fixture/generatedTypeScript/classes/Resource.ts
@@ -41,7 +41,7 @@ export class Resource extends Type {
 
   constructor() {
     super();
-    this.resourceType = this.constructor.name;
+    this.resourceType = this.getTypeName();
   }
   
   public static parse(


### PR DESCRIPTION
Fixed a `constructor.name` issue that was fixed upstream in fhir-typescript-models. This prevents that upstream fix from being wiped out, and adds a test case.