### PR TITLE
Fixing poorly named "type" property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "model-info-parser",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-info-parser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This is a library to parse a modelinfo.xml specification file and generate libraries conforming to that specification.",
   "main": "dist/generateTypeScript.js",
   "repository": {

--- a/src/templates/typescript/classes/classTemplate.ts
+++ b/src/templates/typescript/classes/classTemplate.ts
@@ -50,7 +50,7 @@ export class {{ dataType.normalizedName }}{{# if parentDataType }} extends {{ pa
     return parentTypeRef || null;
   }
 
-  get type(): typeof Type {
+  get fhirTypeRef(): typeof Type {
     const typeName = getTypeName(this) || "";
     const typeRef = lookupType(typeName);
     if (!typeRef) {

--- a/test/FieldInfo.test.ts
+++ b/test/FieldInfo.test.ts
@@ -81,3 +81,10 @@ describe("Decorators", () => {
     expect(KitchenSink.fieldInfo).toBeArrayOfSize(9);
   });
 });
+
+describe("fhirTypeRef", () => {
+  it("should dynamically retrieve an object's FHIR type at runtime", () => {
+    const sink = new KitchenSink();
+    expect(sink.fhirTypeRef).toBe(KitchenSink);
+  });
+});

--- a/test/fixture/generatedTypeScript/classes/Type.ts
+++ b/test/fixture/generatedTypeScript/classes/Type.ts
@@ -30,7 +30,7 @@ export class Type {
     return parentTypeRef || null;
   }
 
-  get type(): typeof Type {
+  get fhirTypeRef(): typeof Type {
     const typeName = getTypeName(this) || "";
     const typeRef = lookupType(typeName);
     if (!typeRef) {


### PR DESCRIPTION
Renaming the poorly named "type" property to "fhirTypeRef" to avoid conflicts with actual FHIR attributes.